### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -10,6 +10,15 @@ info:
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
+servers:
+  - url: https://openrouter.ai/api/v1
+    description: Production server
+    x-speakeasy-server-id: production
+security:
+  - apiKey: []
+externalDocs:
+  description: OpenRouter Documentation
+  url: https://openrouter.ai/docs
 components:
   schemas:
     OpenAIResponsesResponseStatus:
@@ -200,6 +209,19 @@ components:
             anyOf:
               - $ref: '#/components/schemas/ResponseOutputText'
               - $ref: '#/components/schemas/OpenAIResponsesRefusalContent'
+        phase:
+          anyOf:
+            - type: string
+              enum:
+                - commentary
+            - type: string
+              enum:
+                - final_answer
+            - nullable: true
+          description: >-
+            The phase of an assistant message. Use `commentary` for an intermediate assistant message and `final_answer`
+            for the final assistant message. For follow-up requests with models like `gpt-5.3-codex` and later, preserve
+            and resend phase on all assistant messages. Omitting it can degrade performance. Not used for user messages.
       required:
         - id
         - role
@@ -213,7 +235,7 @@ components:
         content:
           - type: output_text
             text: Hello! How can I help you today?
-    ResponsesOutputMessage:
+    OutputMessageItem:
       allOf:
         - $ref: '#/components/schemas/OutputMessage'
         - type: object
@@ -299,11 +321,16 @@ components:
         summary:
           - type: summary_text
             text: Analyzed the problem using first principles
-    ResponsesOutputItemReasoning:
+    OutputReasoningItem:
       allOf:
         - $ref: '#/components/schemas/OutputItemReasoning'
         - type: object
           properties:
+            content:
+              type: array
+              nullable: true
+              items:
+                $ref: '#/components/schemas/ReasoningTextContent'
             signature:
               type: string
               nullable: true
@@ -371,7 +398,7 @@ components:
         name: get_weather
         arguments: '{"location":"San Francisco","unit":"celsius"}'
         call_id: call-abc123
-    ResponsesOutputItemFunctionCall:
+    OutputFunctionCallItem:
       allOf:
         - $ref: '#/components/schemas/OutputItemFunctionCall'
         - type: object
@@ -399,17 +426,77 @@ components:
             - web_search_call
         id:
           type: string
+        action:
+          oneOf:
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - search
+                query:
+                  type: string
+                queries:
+                  type: array
+                  items:
+                    type: string
+                sources:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - url
+                      url:
+                        type: string
+                    required:
+                      - type
+                      - url
+              required:
+                - type
+                - query
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - open_page
+                url:
+                  type: string
+                  nullable: true
+              required:
+                - type
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - find_in_page
+                pattern:
+                  type: string
+                url:
+                  type: string
+              required:
+                - type
+                - pattern
+                - url
         status:
           $ref: '#/components/schemas/WebSearchStatus'
       required:
         - type
         - id
+        - action
         - status
       example:
         type: web_search_call
         id: search-abc123
+        action:
+          type: search
+          query: OpenAI API
         status: completed
-    ResponsesWebSearchCallOutput:
+    OutputWebSearchCallItem:
       allOf:
         - $ref: '#/components/schemas/OutputItemWebSearchCall'
         - type: object
@@ -417,6 +504,9 @@ components:
       example:
         type: web_search_call
         id: search-abc123
+        action:
+          type: search
+          query: OpenAI API
         status: completed
     OutputItemFileSearchCall:
       type: object
@@ -445,7 +535,7 @@ components:
           - machine learning algorithms
           - neural networks
         status: completed
-    ResponsesOutputItemFileSearchCall:
+    OutputFileSearchCallItem:
       allOf:
         - $ref: '#/components/schemas/OutputItemFileSearchCall'
         - type: object
@@ -489,7 +579,7 @@ components:
         id: imagegen-abc123
         result: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==
         status: completed
-    ResponsesImageGenerationCall:
+    OutputImageGenerationCallItem:
       allOf:
         - $ref: '#/components/schemas/OutputItemImageGenerationCall'
         - type: object
@@ -499,14 +589,40 @@ components:
         id: imagegen-abc123
         result: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==
         status: completed
-    ResponsesOutputItem:
+    OutputServerToolItem:
+      type: object
+      properties:
+        type:
+          type: string
+          pattern: '^openrouter:'
+          description: Server tool type (e.g. openrouter:datetime, openrouter:web_search)
+        id:
+          type: string
+        status:
+          type: string
+          enum:
+            - completed
+            - in_progress
+            - incomplete
+      required:
+        - type
+        - status
+      additionalProperties:
+        nullable: true
+      description: A generic OpenRouter server tool output item
+      example:
+        type: openrouter:web_search
+        id: ws_tmp_abc123
+        status: completed
+    OutputItems:
       anyOf:
-        - $ref: '#/components/schemas/ResponsesOutputMessage'
-        - $ref: '#/components/schemas/ResponsesOutputItemReasoning'
-        - $ref: '#/components/schemas/ResponsesOutputItemFunctionCall'
-        - $ref: '#/components/schemas/ResponsesWebSearchCallOutput'
-        - $ref: '#/components/schemas/ResponsesOutputItemFileSearchCall'
-        - $ref: '#/components/schemas/ResponsesImageGenerationCall'
+        - $ref: '#/components/schemas/OutputMessageItem'
+        - $ref: '#/components/schemas/OutputReasoningItem'
+        - $ref: '#/components/schemas/OutputFunctionCallItem'
+        - $ref: '#/components/schemas/OutputWebSearchCallItem'
+        - $ref: '#/components/schemas/OutputFileSearchCallItem'
+        - $ref: '#/components/schemas/OutputImageGenerationCallItem'
+        - $ref: '#/components/schemas/OutputServerToolItem'
       description: An output item from the response
       example:
         id: msg-abc123
@@ -550,7 +666,7 @@ components:
       example:
         code: rate_limit_exceeded
         message: Rate limit exceeded. Please try again later.
-    OpenAIResponsesIncompleteDetails:
+    IncompleteDetails:
       type: object
       nullable: true
       properties:
@@ -588,7 +704,7 @@ components:
         - output_tokens
         - output_tokens_details
         - total_tokens
-    OpenResponsesUsage:
+    Usage:
       allOf:
         - $ref: '#/components/schemas/OpenAIResponsesUsage'
         - type: object
@@ -606,11 +722,13 @@ components:
               properties:
                 upstream_inference_cost:
                   type: number
-                  nullable: true
+                  format: double
                 upstream_inference_input_cost:
                   type: number
+                  format: double
                 upstream_inference_output_cost:
                   type: number
+                  format: double
               required:
                 - upstream_inference_input_cost
                 - upstream_inference_output_cost
@@ -628,7 +746,7 @@ components:
           upstream_inference_cost: null
           upstream_inference_input_cost: 0.0008
           upstream_inference_output_cost: 0.0004
-    ResponseInputText:
+    InputText:
       type: object
       properties:
         type:
@@ -644,7 +762,7 @@ components:
       example:
         type: input_text
         text: Hello, how can I help you?
-    ResponseInputImage:
+    InputImage:
       type: object
       properties:
         type:
@@ -668,7 +786,7 @@ components:
         type: input_image
         detail: auto
         image_url: https://example.com/image.jpg
-    ResponseInputFile:
+    InputFile:
       type: object
       properties:
         type:
@@ -691,7 +809,7 @@ components:
         type: input_file
         file_id: file-abc123
         filename: document.pdf
-    ResponseInputAudio:
+    InputAudio:
       type: object
       properties:
         type:
@@ -720,7 +838,7 @@ components:
         input_audio:
           data: SGVsbG8gV29ybGQ=
           format: mp3
-    ToolCallStatus:
+    ToolCallStatusEnum:
       type: string
       nullable: true
       enum:
@@ -728,7 +846,7 @@ components:
         - completed
         - incomplete
       example: completed
-    OpenAIResponsesInput:
+    BaseInputs:
       anyOf:
         - type: string
         - type: array
@@ -759,18 +877,27 @@ components:
                       - type: array
                         items:
                           oneOf:
-                            - $ref: '#/components/schemas/ResponseInputText'
-                            - $ref: '#/components/schemas/ResponseInputImage'
-                            - $ref: '#/components/schemas/ResponseInputFile'
-                            - $ref: '#/components/schemas/ResponseInputAudio'
+                            - $ref: '#/components/schemas/InputText'
+                            - $ref: '#/components/schemas/InputImage'
+                            - $ref: '#/components/schemas/InputFile'
+                            - $ref: '#/components/schemas/InputAudio'
                           discriminator:
                             propertyName: type
                             mapping:
-                              input_text: '#/components/schemas/ResponseInputText'
-                              input_image: '#/components/schemas/ResponseInputImage'
-                              input_file: '#/components/schemas/ResponseInputFile'
-                              input_audio: '#/components/schemas/ResponseInputAudio'
+                              input_text: '#/components/schemas/InputText'
+                              input_image: '#/components/schemas/InputImage'
+                              input_file: '#/components/schemas/InputFile'
+                              input_audio: '#/components/schemas/InputAudio'
                       - type: string
+                  phase:
+                    anyOf:
+                      - type: string
+                        enum:
+                          - commentary
+                      - type: string
+                        enum:
+                          - final_answer
+                      - nullable: true
                 required:
                   - role
                   - content
@@ -797,17 +924,17 @@ components:
                     type: array
                     items:
                       oneOf:
-                        - $ref: '#/components/schemas/ResponseInputText'
-                        - $ref: '#/components/schemas/ResponseInputImage'
-                        - $ref: '#/components/schemas/ResponseInputFile'
-                        - $ref: '#/components/schemas/ResponseInputAudio'
+                        - $ref: '#/components/schemas/InputText'
+                        - $ref: '#/components/schemas/InputImage'
+                        - $ref: '#/components/schemas/InputFile'
+                        - $ref: '#/components/schemas/InputAudio'
                       discriminator:
                         propertyName: type
                         mapping:
-                          input_text: '#/components/schemas/ResponseInputText'
-                          input_image: '#/components/schemas/ResponseInputImage'
-                          input_file: '#/components/schemas/ResponseInputFile'
-                          input_audio: '#/components/schemas/ResponseInputAudio'
+                          input_text: '#/components/schemas/InputText'
+                          input_image: '#/components/schemas/InputImage'
+                          input_file: '#/components/schemas/InputFile'
+                          input_audio: '#/components/schemas/InputAudio'
                 required:
                   - id
                   - role
@@ -824,9 +951,22 @@ components:
                   call_id:
                     type: string
                   output:
-                    type: string
+                    anyOf:
+                      - type: string
+                      - type: array
+                        items:
+                          oneOf:
+                            - $ref: '#/components/schemas/InputText'
+                            - $ref: '#/components/schemas/InputImage'
+                            - $ref: '#/components/schemas/InputFile'
+                          discriminator:
+                            propertyName: type
+                            mapping:
+                              input_text: '#/components/schemas/InputText'
+                              input_image: '#/components/schemas/InputImage'
+                              input_file: '#/components/schemas/InputFile'
                   status:
-                    $ref: '#/components/schemas/ToolCallStatus'
+                    $ref: '#/components/schemas/ToolCallStatusEnum'
                 required:
                   - type
                   - call_id
@@ -846,7 +986,7 @@ components:
                   id:
                     type: string
                   status:
-                    $ref: '#/components/schemas/ToolCallStatus'
+                    $ref: '#/components/schemas/ToolCallStatusEnum'
                 required:
                   - type
                   - call_id
@@ -855,7 +995,7 @@ components:
               - $ref: '#/components/schemas/OutputItemImageGenerationCall'
               - $ref: '#/components/schemas/OutputMessage'
         - nullable: true
-    OpenResponsesRequestMetadata:
+    RequestMetadata:
       type: object
       nullable: true
       additionalProperties:
@@ -867,7 +1007,7 @@ components:
       example:
         user_id: '123'
         session_id: abc-def-ghi
-    OpenResponsesFunctionTool:
+    FunctionTool:
       type: object
       properties:
         type:
@@ -909,7 +1049,7 @@ components:
                 - fahrenheit
           required:
             - location
-    ResponsesSearchContextSize:
+    SearchContextSizeEnum:
       type: string
       enum:
         - low
@@ -917,7 +1057,7 @@ components:
         - high
       description: Size of the search context for web search tools
       example: medium
-    WebSearchPreviewToolUserLocation:
+    Preview_WebSearchUserLocation:
       type: object
       nullable: true
       properties:
@@ -939,7 +1079,7 @@ components:
           nullable: true
       required:
         - type
-    OpenResponsesWebSearchPreviewTool:
+    Preview_WebSearchServerTool:
       type: object
       properties:
         type:
@@ -947,15 +1087,50 @@ components:
           enum:
             - web_search_preview
         search_context_size:
-          $ref: '#/components/schemas/ResponsesSearchContextSize'
+          $ref: '#/components/schemas/SearchContextSizeEnum'
         user_location:
-          $ref: '#/components/schemas/WebSearchPreviewToolUserLocation'
+          $ref: '#/components/schemas/Preview_WebSearchUserLocation'
+        engine:
+          type: string
+          enum:
+            - auto
+            - native
+            - exa
+            - firecrawl
+            - parallel
+          description: >-
+            Which search engine to use. "auto" (default) uses native if the provider supports it, otherwise Exa.
+            "native" forces the provider's built-in search. "exa" forces the Exa search API. "firecrawl" uses Firecrawl
+            (requires BYOK). "parallel" uses the Parallel search API.
+          example: auto
+        max_results:
+          type: number
+          minimum: 1
+          maximum: 25
+          description: >-
+            Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and
+            Parallel engines; ignored with native provider search.
+          example: 5
+        filters:
+          type: object
+          nullable: true
+          properties:
+            allowed_domains:
+              type: array
+              nullable: true
+              items:
+                type: string
+            excluded_domains:
+              type: array
+              nullable: true
+              items:
+                type: string
       required:
         - type
       description: Web search preview tool configuration
       example:
         type: web_search_preview
-    OpenResponsesWebSearchPreview20250311Tool:
+    Preview_20250311_WebSearchServerTool:
       type: object
       properties:
         type:
@@ -963,15 +1138,50 @@ components:
           enum:
             - web_search_preview_2025_03_11
         search_context_size:
-          $ref: '#/components/schemas/ResponsesSearchContextSize'
+          $ref: '#/components/schemas/SearchContextSizeEnum'
         user_location:
-          $ref: '#/components/schemas/WebSearchPreviewToolUserLocation'
+          $ref: '#/components/schemas/Preview_WebSearchUserLocation'
+        engine:
+          type: string
+          enum:
+            - auto
+            - native
+            - exa
+            - firecrawl
+            - parallel
+          description: >-
+            Which search engine to use. "auto" (default) uses native if the provider supports it, otherwise Exa.
+            "native" forces the provider's built-in search. "exa" forces the Exa search API. "firecrawl" uses Firecrawl
+            (requires BYOK). "parallel" uses the Parallel search API.
+          example: auto
+        max_results:
+          type: number
+          minimum: 1
+          maximum: 25
+          description: >-
+            Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and
+            Parallel engines; ignored with native provider search.
+          example: 5
+        filters:
+          type: object
+          nullable: true
+          properties:
+            allowed_domains:
+              type: array
+              nullable: true
+              items:
+                type: string
+            excluded_domains:
+              type: array
+              nullable: true
+              items:
+                type: string
       required:
         - type
       description: Web search preview tool configuration (2025-03-11 version)
       example:
         type: web_search_preview_2025_03_11
-    ResponsesWebSearchUserLocation:
+    WebSearchUserLocation:
       type: object
       nullable: true
       properties:
@@ -998,7 +1208,7 @@ components:
         country: USA
         region: California
         timezone: America/Los_Angeles
-    OpenResponsesWebSearchTool:
+    Legacy_WebSearchServerTool:
       type: object
       properties:
         type:
@@ -1014,19 +1224,46 @@ components:
               nullable: true
               items:
                 type: string
+            excluded_domains:
+              type: array
+              nullable: true
+              items:
+                type: string
         search_context_size:
-          $ref: '#/components/schemas/ResponsesSearchContextSize'
+          $ref: '#/components/schemas/SearchContextSizeEnum'
         user_location:
-          $ref: '#/components/schemas/ResponsesWebSearchUserLocation'
+          $ref: '#/components/schemas/WebSearchUserLocation'
+        engine:
+          type: string
+          enum:
+            - auto
+            - native
+            - exa
+            - firecrawl
+            - parallel
+          description: >-
+            Which search engine to use. "auto" (default) uses native if the provider supports it, otherwise Exa.
+            "native" forces the provider's built-in search. "exa" forces the Exa search API. "firecrawl" uses Firecrawl
+            (requires BYOK). "parallel" uses the Parallel search API.
+          example: auto
+        max_results:
+          type: number
+          minimum: 1
+          maximum: 25
+          description: >-
+            Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and
+            Parallel engines; ignored with native provider search.
+          example: 5
       required:
         - type
       description: Web search tool configuration
       example:
         type: web_search
+        engine: auto
         filters:
           allowed_domains:
             - example.com
-    OpenResponsesWebSearch20250826Tool:
+    WebSearchServerTool:
       type: object
       properties:
         type:
@@ -1042,18 +1279,454 @@ components:
               nullable: true
               items:
                 type: string
+            excluded_domains:
+              type: array
+              nullable: true
+              items:
+                type: string
         search_context_size:
-          $ref: '#/components/schemas/ResponsesSearchContextSize'
+          $ref: '#/components/schemas/SearchContextSizeEnum'
         user_location:
-          $ref: '#/components/schemas/ResponsesWebSearchUserLocation'
+          $ref: '#/components/schemas/WebSearchUserLocation'
+        engine:
+          type: string
+          enum:
+            - auto
+            - native
+            - exa
+            - firecrawl
+            - parallel
+          description: >-
+            Which search engine to use. "auto" (default) uses native if the provider supports it, otherwise Exa.
+            "native" forces the provider's built-in search. "exa" forces the Exa search API. "firecrawl" uses Firecrawl
+            (requires BYOK). "parallel" uses the Parallel search API.
+          example: auto
+        max_results:
+          type: number
+          minimum: 1
+          maximum: 25
+          description: >-
+            Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and
+            Parallel engines; ignored with native provider search.
+          example: 5
       required:
         - type
       description: Web search tool configuration (2025-08-26 version)
       example:
         type: web_search_2025_08_26
+        engine: auto
         filters:
           allowed_domains:
             - example.com
+    CompoundFilter:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - and
+            - or
+        filters:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              nullable: true
+      required:
+        - type
+        - filters
+      description: A compound filter that combines multiple comparison or compound filters
+    FileSearchServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - file_search
+        vector_store_ids:
+          type: array
+          items:
+            type: string
+        filters:
+          anyOf:
+            - type: object
+              properties:
+                key:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - eq
+                    - ne
+                    - gt
+                    - gte
+                    - lt
+                    - lte
+                value:
+                  anyOf:
+                    - type: string
+                    - type: number
+                      format: double
+                    - type: boolean
+                    - type: array
+                      items:
+                        anyOf:
+                          - type: string
+                          - type: number
+                            format: double
+              required:
+                - key
+                - type
+                - value
+            - $ref: '#/components/schemas/CompoundFilter'
+            - nullable: true
+        max_num_results:
+          type: integer
+        ranking_options:
+          type: object
+          properties:
+            ranker:
+              type: string
+              enum:
+                - auto
+                - default-2024-11-15
+            score_threshold:
+              type: number
+              format: double
+      required:
+        - type
+        - vector_store_ids
+      description: File search tool configuration
+      example:
+        type: file_search
+        vector_store_ids:
+          - vs_abc123
+    ComputerUseServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - computer_use_preview
+        display_height:
+          type: integer
+        display_width:
+          type: integer
+        environment:
+          type: string
+          enum:
+            - windows
+            - mac
+            - linux
+            - ubuntu
+            - browser
+      required:
+        - type
+        - display_height
+        - display_width
+        - environment
+      description: Computer use preview tool configuration
+      example:
+        type: computer_use_preview
+        display_height: 768
+        display_width: 1024
+        environment: linux
+    CodeInterpreterServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - code_interpreter
+        container:
+          anyOf:
+            - type: string
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - auto
+                file_ids:
+                  type: array
+                  items:
+                    type: string
+                memory_limit:
+                  type: string
+                  nullable: true
+                  enum:
+                    - 1g
+                    - 4g
+                    - 16g
+                    - 64g
+              required:
+                - type
+      required:
+        - type
+        - container
+      description: Code interpreter tool configuration
+      example:
+        type: code_interpreter
+        container: auto
+    McpServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - mcp
+        server_label:
+          type: string
+        allowed_tools:
+          anyOf:
+            - type: array
+              items:
+                type: string
+            - type: object
+              properties:
+                tool_names:
+                  type: array
+                  items:
+                    type: string
+                read_only:
+                  type: boolean
+            - nullable: true
+            - nullable: true
+        authorization:
+          type: string
+        connector_id:
+          type: string
+          enum:
+            - connector_dropbox
+            - connector_gmail
+            - connector_googlecalendar
+            - connector_googledrive
+            - connector_microsoftteams
+            - connector_outlookcalendar
+            - connector_outlookemail
+            - connector_sharepoint
+        headers:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
+        require_approval:
+          anyOf:
+            - type: object
+              properties:
+                never:
+                  type: object
+                  properties:
+                    tool_names:
+                      type: array
+                      items:
+                        type: string
+                always:
+                  type: object
+                  properties:
+                    tool_names:
+                      type: array
+                      items:
+                        type: string
+            - type: string
+              enum:
+                - always
+            - type: string
+              enum:
+                - never
+            - nullable: true
+            - nullable: true
+        server_description:
+          type: string
+        server_url:
+          type: string
+      required:
+        - type
+        - server_label
+      description: MCP (Model Context Protocol) tool configuration
+      example:
+        type: mcp
+        server_label: my-server
+        server_url: https://example.com/mcp
+    ImageGenerationServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - image_generation
+        background:
+          type: string
+          enum:
+            - transparent
+            - opaque
+            - auto
+        input_fidelity:
+          type: string
+          nullable: true
+          enum:
+            - high
+            - low
+        input_image_mask:
+          type: object
+          properties:
+            image_url:
+              type: string
+            file_id:
+              type: string
+        model:
+          type: string
+          enum:
+            - gpt-image-1
+            - gpt-image-1-mini
+        moderation:
+          type: string
+          enum:
+            - auto
+            - low
+        output_compression:
+          type: integer
+        output_format:
+          type: string
+          enum:
+            - png
+            - webp
+            - jpeg
+        partial_images:
+          type: integer
+        quality:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+            - auto
+        size:
+          type: string
+          enum:
+            - 1024x1024
+            - 1024x1536
+            - 1536x1024
+            - auto
+      required:
+        - type
+      description: Image generation tool configuration
+      example:
+        type: image_generation
+        quality: high
+    CodexLocalShellTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - local_shell
+      required:
+        - type
+      description: Local shell tool configuration
+      example:
+        type: local_shell
+    ShellServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - shell
+      required:
+        - type
+      description: Shell tool configuration
+      example:
+        type: shell
+    ApplyPatchServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - apply_patch
+      required:
+        - type
+      description: Apply patch tool configuration
+      example:
+        type: apply_patch
+    CustomTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - custom
+        name:
+          type: string
+        description:
+          type: string
+        format:
+          anyOf:
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - text
+              required:
+                - type
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - grammar
+                definition:
+                  type: string
+                syntax:
+                  type: string
+                  enum:
+                    - lark
+                    - regex
+              required:
+                - type
+                - definition
+                - syntax
+      required:
+        - type
+        - name
+      description: Custom tool configuration
+      example:
+        type: custom
+        name: my_tool
+    ToolChoiceAllowed:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - allowed_tools
+        mode:
+          anyOf:
+            - type: string
+              enum:
+                - auto
+            - type: string
+              enum:
+                - required
+        tools:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              nullable: true
+      required:
+        - type
+        - mode
+        - tools
+      description: Constrains the model to a pre-defined set of allowed tools
+      example:
+        type: allowed_tools
+        mode: auto
+        tools:
+          - type: function
+            name: get_weather
     OpenAIResponsesToolChoice:
       anyOf:
         - type: string
@@ -1088,7 +1761,8 @@ components:
                     - web_search_preview
           required:
             - type
-    OpenAIResponsesPrompt:
+        - $ref: '#/components/schemas/ToolChoiceAllowed'
+    StoredPromptTemplate:
       type: object
       nullable: true
       properties:
@@ -1100,12 +1774,12 @@ components:
           additionalProperties:
             anyOf:
               - type: string
-              - $ref: '#/components/schemas/ResponseInputText'
-              - $ref: '#/components/schemas/ResponseInputImage'
-              - $ref: '#/components/schemas/ResponseInputFile'
+              - $ref: '#/components/schemas/InputText'
+              - $ref: '#/components/schemas/InputImage'
+              - $ref: '#/components/schemas/InputFile'
       required:
         - id
-    OpenAIResponsesReasoningEffort:
+    ReasoningEffortEnum:
       type: string
       nullable: true
       enum:
@@ -1115,36 +1789,29 @@ components:
         - low
         - minimal
         - none
-    ReasoningSummaryVerbosity:
+    ReasoningSummaryVerbosityEnum:
       type: string
+      nullable: true
       enum:
         - auto
         - concise
         - detailed
-    OpenAIResponsesReasoningConfig:
+      example: auto
+    BaseReasoningConfig:
       type: object
       nullable: true
       properties:
         effort:
-          $ref: '#/components/schemas/OpenAIResponsesReasoningEffort'
+          $ref: '#/components/schemas/ReasoningEffortEnum'
         summary:
-          $ref: '#/components/schemas/ReasoningSummaryVerbosity'
-    OpenAIResponsesServiceTier:
-      type: string
-      nullable: true
-      enum:
-        - auto
-        - default
-        - flex
-        - priority
-        - scale
-    OpenAIResponsesTruncation:
+          $ref: '#/components/schemas/ReasoningSummaryVerbosityEnum'
+    TruncationEnum:
       type: string
       nullable: true
       enum:
         - auto
         - disabled
-    ResponsesFormatText:
+    FormatTextConfig:
       type: object
       properties:
         type:
@@ -1156,7 +1823,7 @@ components:
       description: Plain text response format
       example:
         type: text
-    ResponsesFormatJSONObject:
+    FormatJsonObjectConfig:
       type: object
       properties:
         type:
@@ -1168,7 +1835,7 @@ components:
       description: JSON object response format
       example:
         type: json_object
-    ResponsesFormatTextJSONSchemaConfig:
+    FormatJsonSchemaConfig:
       type: object
       properties:
         type:
@@ -1204,19 +1871,19 @@ components:
               type: number
           required:
             - name
-    ResponseFormatTextConfig:
+    Formats:
       anyOf:
-        - $ref: '#/components/schemas/ResponsesFormatText'
-        - $ref: '#/components/schemas/ResponsesFormatJSONObject'
-        - $ref: '#/components/schemas/ResponsesFormatTextJSONSchemaConfig'
+        - $ref: '#/components/schemas/FormatTextConfig'
+        - $ref: '#/components/schemas/FormatJsonObjectConfig'
+        - $ref: '#/components/schemas/FormatJsonSchemaConfig'
       description: Text response format configuration
       example:
         type: text
-    ResponseTextConfig:
+    TextConfig:
       type: object
       properties:
         format:
-          $ref: '#/components/schemas/ResponseFormatTextConfig'
+          $ref: '#/components/schemas/Formats'
         verbosity:
           type: string
           nullable: true
@@ -1229,7 +1896,16 @@ components:
         format:
           type: text
         verbosity: medium
-    OpenAIResponsesNonStreamingResponse:
+    ServiceTierEnum:
+      type: string
+      nullable: true
+      enum:
+        - auto
+        - default
+        - flex
+        - priority
+        - scale
+    BaseResponsesResult:
       type: object
       properties:
         id:
@@ -1239,14 +1915,13 @@ components:
           enum:
             - response
         created_at:
-          type: number
+          type: integer
         model:
           type: string
         status:
           $ref: '#/components/schemas/OpenAIResponsesResponseStatus'
         completed_at:
-          type: number
-          nullable: true
+          type: integer
         output:
           type: array
           items:
@@ -1280,39 +1955,37 @@ components:
         error:
           $ref: '#/components/schemas/ResponsesErrorField'
         incomplete_details:
-          $ref: '#/components/schemas/OpenAIResponsesIncompleteDetails'
+          $ref: '#/components/schemas/IncompleteDetails'
         usage:
           $ref: '#/components/schemas/OpenAIResponsesUsage'
         max_tool_calls:
-          type: number
-          nullable: true
+          type: integer
         top_logprobs:
-          type: number
+          type: integer
         max_output_tokens:
-          type: number
-          nullable: true
+          type: integer
         temperature:
           type: number
-          nullable: true
+          format: double
         top_p:
           type: number
-          nullable: true
+          format: double
         presence_penalty:
           type: number
-          nullable: true
+          format: double
         frequency_penalty:
           type: number
-          nullable: true
+          format: double
         instructions:
-          $ref: '#/components/schemas/OpenAIResponsesInput'
+          $ref: '#/components/schemas/BaseInputs'
         metadata:
-          $ref: '#/components/schemas/OpenResponsesRequestMetadata'
+          $ref: '#/components/schemas/RequestMetadata'
         tools:
           type: array
           items:
             oneOf:
               - allOf:
-                  - $ref: '#/components/schemas/OpenResponsesFunctionTool'
+                  - $ref: '#/components/schemas/FunctionTool'
                   - type: object
                     properties: {}
                 description: Function tool definition
@@ -1333,16 +2006,25 @@ components:
                           - fahrenheit
                     required:
                       - location
-              - $ref: '#/components/schemas/OpenResponsesWebSearchPreviewTool'
-              - $ref: '#/components/schemas/OpenResponsesWebSearchPreview20250311Tool'
-              - $ref: '#/components/schemas/OpenResponsesWebSearchTool'
-              - $ref: '#/components/schemas/OpenResponsesWebSearch20250826Tool'
+              - $ref: '#/components/schemas/Preview_WebSearchServerTool'
+              - $ref: '#/components/schemas/Preview_20250311_WebSearchServerTool'
+              - $ref: '#/components/schemas/Legacy_WebSearchServerTool'
+              - $ref: '#/components/schemas/WebSearchServerTool'
+              - $ref: '#/components/schemas/FileSearchServerTool'
+              - $ref: '#/components/schemas/ComputerUseServerTool'
+              - $ref: '#/components/schemas/CodeInterpreterServerTool'
+              - $ref: '#/components/schemas/McpServerTool'
+              - $ref: '#/components/schemas/ImageGenerationServerTool'
+              - $ref: '#/components/schemas/CodexLocalShellTool'
+              - $ref: '#/components/schemas/ShellServerTool'
+              - $ref: '#/components/schemas/ApplyPatchServerTool'
+              - $ref: '#/components/schemas/CustomTool'
         tool_choice:
           $ref: '#/components/schemas/OpenAIResponsesToolChoice'
         parallel_tool_calls:
           type: boolean
         prompt:
-          $ref: '#/components/schemas/OpenAIResponsesPrompt'
+          $ref: '#/components/schemas/StoredPromptTemplate'
         background:
           type: boolean
           nullable: true
@@ -1350,15 +2032,15 @@ components:
           type: string
           nullable: true
         reasoning:
-          $ref: '#/components/schemas/OpenAIResponsesReasoningConfig'
+          $ref: '#/components/schemas/BaseReasoningConfig'
         service_tier:
-          $ref: '#/components/schemas/OpenAIResponsesServiceTier'
+          $ref: '#/components/schemas/ServiceTierEnum'
         store:
           type: boolean
         truncation:
-          $ref: '#/components/schemas/OpenAIResponsesTruncation'
+          $ref: '#/components/schemas/TruncationEnum'
         text:
-          $ref: '#/components/schemas/ResponseTextConfig'
+          $ref: '#/components/schemas/TextConfig'
       required:
         - id
         - object
@@ -1378,17 +2060,20 @@ components:
         - tools
         - tool_choice
         - parallel_tool_calls
-    OpenResponsesNonStreamingResponse:
+    OpenResponsesResult:
       allOf:
-        - $ref: '#/components/schemas/OpenAIResponsesNonStreamingResponse'
+        - $ref: '#/components/schemas/BaseResponsesResult'
         - type: object
           properties:
             output:
               type: array
               items:
-                $ref: '#/components/schemas/ResponsesOutputItem'
+                $ref: '#/components/schemas/OutputItems'
             usage:
-              $ref: '#/components/schemas/OpenResponsesUsage'
+              $ref: '#/components/schemas/Usage'
+            service_tier:
+              type: string
+              nullable: true
       description: Complete non-streaming response from the Responses API
       example:
         id: resp-abc123
@@ -1423,7 +2108,7 @@ components:
         max_output_tokens: null
         metadata: null
         instructions: null
-    OpenResponsesCreatedEvent:
+    CreatedEvent:
       type: object
       properties:
         type:
@@ -1431,9 +2116,9 @@ components:
           enum:
             - response.created
         response:
-          $ref: '#/components/schemas/OpenAIResponsesNonStreamingResponse'
+          $ref: '#/components/schemas/BaseResponsesResult'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - response
@@ -1459,7 +2144,7 @@ components:
           top_p: null
           max_output_tokens: null
         sequence_number: 0
-    OpenResponsesInProgressEvent:
+    InProgressEvent:
       type: object
       properties:
         type:
@@ -1467,9 +2152,9 @@ components:
           enum:
             - response.in_progress
         response:
-          $ref: '#/components/schemas/OpenAIResponsesNonStreamingResponse'
+          $ref: '#/components/schemas/BaseResponsesResult'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - response
@@ -1495,7 +2180,7 @@ components:
           top_p: null
           max_output_tokens: null
         sequence_number: 1
-    OpenResponsesCompletedEvent:
+    CompletedEvent:
       type: object
       properties:
         type:
@@ -1503,9 +2188,9 @@ components:
           enum:
             - response.completed
         response:
-          $ref: '#/components/schemas/OpenAIResponsesNonStreamingResponse'
+          $ref: '#/components/schemas/BaseResponsesResult'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - response
@@ -1539,7 +2224,7 @@ components:
           top_p: null
           max_output_tokens: null
         sequence_number: 10
-    OpenResponsesIncompleteEvent:
+    IncompleteEvent:
       type: object
       properties:
         type:
@@ -1547,9 +2232,9 @@ components:
           enum:
             - response.incomplete
         response:
-          $ref: '#/components/schemas/OpenAIResponsesNonStreamingResponse'
+          $ref: '#/components/schemas/BaseResponsesResult'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - response
@@ -1575,7 +2260,7 @@ components:
           top_p: null
           max_output_tokens: null
         sequence_number: 5
-    OpenResponsesFailedEvent:
+    FailedEvent:
       type: object
       properties:
         type:
@@ -1583,9 +2268,9 @@ components:
           enum:
             - response.failed
         response:
-          $ref: '#/components/schemas/OpenAIResponsesNonStreamingResponse'
+          $ref: '#/components/schemas/BaseResponsesResult'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - response
@@ -1611,7 +2296,7 @@ components:
           top_p: null
           max_output_tokens: null
         sequence_number: 3
-    OpenAIResponsesErrorEvent:
+    BaseErrorEvent:
       type: object
       properties:
         type:
@@ -1627,7 +2312,7 @@ components:
           type: string
           nullable: true
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - code
@@ -1641,9 +2326,9 @@ components:
         message: Rate limit exceeded. Please try again later.
         param: null
         sequence_number: 2
-    OpenResponsesErrorEvent:
+    ErrorEvent:
       allOf:
-        - $ref: '#/components/schemas/OpenAIResponsesErrorEvent'
+        - $ref: '#/components/schemas/BaseErrorEvent'
         - type: object
           properties: {}
       description: Event emitted when an error occurs during streaming
@@ -1653,7 +2338,7 @@ components:
         message: Rate limit exceeded. Please try again later.
         param: null
         sequence_number: 2
-    OpenResponsesOutputItemAddedEvent:
+    OutputItemAddedEvent:
       type: object
       properties:
         type:
@@ -1661,7 +2346,7 @@ components:
           enum:
             - response.output_item.added
         output_index:
-          type: number
+          type: integer
         item:
           oneOf:
             - $ref: '#/components/schemas/OutputMessage'
@@ -1680,7 +2365,7 @@ components:
               file_search_call: '#/components/schemas/OutputItemFileSearchCall'
               image_generation_call: '#/components/schemas/OutputItemImageGenerationCall'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -1697,7 +2382,7 @@ components:
           role: assistant
           content: []
         sequence_number: 2
-    OpenResponsesOutputItemDoneEvent:
+    OutputItemDoneEvent:
       type: object
       properties:
         type:
@@ -1705,7 +2390,7 @@ components:
           enum:
             - response.output_item.done
         output_index:
-          type: number
+          type: integer
         item:
           oneOf:
             - $ref: '#/components/schemas/OutputMessage'
@@ -1724,7 +2409,7 @@ components:
               file_search_call: '#/components/schemas/OutputItemFileSearchCall'
               image_generation_call: '#/components/schemas/OutputItemImageGenerationCall'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -1744,7 +2429,7 @@ components:
               text: Hello! How can I help you?
               annotations: []
         sequence_number: 8
-    OpenResponsesContentPartAddedEvent:
+    BaseContentPartAddedEvent:
       type: object
       properties:
         type:
@@ -1752,17 +2437,17 @@ components:
           enum:
             - response.content_part.added
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         part:
           anyOf:
             - $ref: '#/components/schemas/ResponseOutputText'
             - $ref: '#/components/schemas/OpenAIResponsesRefusalContent'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -1781,7 +2466,28 @@ components:
           text: ''
           annotations: []
         sequence_number: 3
-    OpenResponsesContentPartDoneEvent:
+    ContentPartAddedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseContentPartAddedEvent'
+        - type: object
+          properties:
+            part:
+              anyOf:
+                - $ref: '#/components/schemas/ResponseOutputText'
+                - $ref: '#/components/schemas/ReasoningTextContent'
+                - $ref: '#/components/schemas/OpenAIResponsesRefusalContent'
+      description: Event emitted when a new content part is added to an output item
+      example:
+        type: response.content_part.added
+        output_index: 0
+        item_id: item-1
+        content_index: 0
+        part:
+          type: output_text
+          text: ''
+          annotations: []
+        sequence_number: 3
+    BaseContentPartDoneEvent:
       type: object
       properties:
         type:
@@ -1789,17 +2495,17 @@ components:
           enum:
             - response.content_part.done
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         part:
           anyOf:
             - $ref: '#/components/schemas/ResponseOutputText'
             - $ref: '#/components/schemas/OpenAIResponsesRefusalContent'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -1818,6 +2524,27 @@ components:
           text: Hello! How can I help you?
           annotations: []
         sequence_number: 7
+    ContentPartDoneEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseContentPartDoneEvent'
+        - type: object
+          properties:
+            part:
+              anyOf:
+                - $ref: '#/components/schemas/ResponseOutputText'
+                - $ref: '#/components/schemas/ReasoningTextContent'
+                - $ref: '#/components/schemas/OpenAIResponsesRefusalContent'
+      description: Event emitted when a content part is complete
+      example:
+        type: response.content_part.done
+        output_index: 0
+        item_id: item-1
+        content_index: 0
+        part:
+          type: output_text
+          text: Hello! How can I help you?
+          annotations: []
+        sequence_number: 7
     OpenResponsesTopLogprobs:
       type: object
       properties:
@@ -1825,6 +2552,10 @@ components:
           type: string
         logprob:
           type: number
+        bytes:
+          type: array
+          items:
+            type: number
       description: Alternative token with its log probability
       example:
         token: hello
@@ -1840,6 +2571,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenResponsesTopLogprobs'
+        bytes:
+          type: array
+          items:
+            type: number
       required:
         - logprob
         - token
@@ -1850,7 +2585,7 @@ components:
         top_logprobs:
           - token: hello
             logprob: -0.5
-    OpenResponsesTextDeltaEvent:
+    BaseTextDeltaEvent:
       type: object
       properties:
         type:
@@ -1862,15 +2597,15 @@ components:
           items:
             $ref: '#/components/schemas/OpenResponsesLogProbs'
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         delta:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - logprobs
@@ -1888,7 +2623,54 @@ components:
         content_index: 0
         delta: Hello
         sequence_number: 4
-    OpenResponsesTextDoneEvent:
+    TextDeltaEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseTextDeltaEvent'
+        - type: object
+          properties:
+            logprobs:
+              type: array
+              items:
+                allOf:
+                  - $ref: '#/components/schemas/OpenResponsesLogProbs'
+                  - type: object
+                    properties:
+                      top_logprobs:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: '#/components/schemas/OpenResponsesTopLogprobs'
+                            - type: object
+                              properties:
+                                bytes:
+                                  type: array
+                                  items:
+                                    type: integer
+                          description: Alternative token with its log probability
+                          example:
+                            token: hello
+                            logprob: -0.5
+                      bytes:
+                        type: array
+                        items:
+                          type: integer
+                description: Log probability information for a token
+                example:
+                  logprob: -0.1
+                  token: world
+                  top_logprobs:
+                    - token: hello
+                      logprob: -0.5
+      description: Event emitted when a text delta is streamed
+      example:
+        type: response.output_text.delta
+        logprobs: []
+        output_index: 0
+        item_id: item-1
+        content_index: 0
+        delta: Hello
+        sequence_number: 4
+    BaseTextDoneEvent:
       type: object
       properties:
         type:
@@ -1896,15 +2678,15 @@ components:
           enum:
             - response.output_text.done
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         text:
           type: string
         sequence_number:
-          type: number
+          type: integer
         logprobs:
           type: array
           items:
@@ -1926,7 +2708,54 @@ components:
         text: Hello! How can I help you?
         sequence_number: 6
         logprobs: []
-    OpenResponsesRefusalDeltaEvent:
+    TextDoneEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseTextDoneEvent'
+        - type: object
+          properties:
+            logprobs:
+              type: array
+              items:
+                allOf:
+                  - $ref: '#/components/schemas/OpenResponsesLogProbs'
+                  - type: object
+                    properties:
+                      top_logprobs:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: '#/components/schemas/OpenResponsesTopLogprobs'
+                            - type: object
+                              properties:
+                                bytes:
+                                  type: array
+                                  items:
+                                    type: integer
+                          description: Alternative token with its log probability
+                          example:
+                            token: hello
+                            logprob: -0.5
+                      bytes:
+                        type: array
+                        items:
+                          type: integer
+                description: Log probability information for a token
+                example:
+                  logprob: -0.1
+                  token: world
+                  top_logprobs:
+                    - token: hello
+                      logprob: -0.5
+      description: Event emitted when text streaming is complete
+      example:
+        type: response.output_text.done
+        output_index: 0
+        item_id: item-1
+        content_index: 0
+        text: Hello! How can I help you?
+        sequence_number: 6
+        logprobs: []
+    BaseRefusalDeltaEvent:
       type: object
       properties:
         type:
@@ -1934,15 +2763,15 @@ components:
           enum:
             - response.refusal.delta
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         delta:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -1958,7 +2787,20 @@ components:
         content_index: 0
         delta: I'm sorry
         sequence_number: 4
-    OpenResponsesRefusalDoneEvent:
+    RefusalDeltaEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseRefusalDeltaEvent'
+        - type: object
+          properties: {}
+      description: Event emitted when a refusal delta is streamed
+      example:
+        type: response.refusal.delta
+        output_index: 0
+        item_id: item-1
+        content_index: 0
+        delta: I'm sorry
+        sequence_number: 4
+    BaseRefusalDoneEvent:
       type: object
       properties:
         type:
@@ -1966,15 +2808,15 @@ components:
           enum:
             - response.refusal.done
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         refusal:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -1990,7 +2832,20 @@ components:
         content_index: 0
         refusal: I'm sorry, but I can't assist with that request.
         sequence_number: 6
-    OpenResponsesOutputTextAnnotationAddedEvent:
+    RefusalDoneEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseRefusalDoneEvent'
+        - type: object
+          properties: {}
+      description: Event emitted when refusal streaming is complete
+      example:
+        type: response.refusal.done
+        output_index: 0
+        item_id: item-1
+        content_index: 0
+        refusal: I'm sorry, but I can't assist with that request.
+        sequence_number: 6
+    BaseAnnotationAddedEvent:
       type: object
       properties:
         type:
@@ -1998,15 +2853,15 @@ components:
           enum:
             - response.output_text.annotation.added
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         sequence_number:
-          type: number
+          type: integer
         annotation_index:
-          type: number
+          type: integer
         annotation:
           $ref: '#/components/schemas/OpenAIResponsesAnnotation'
       required:
@@ -2031,7 +2886,26 @@ components:
           title: Example
           start_index: 0
           end_index: 7
-    OpenResponsesFunctionCallArgumentsDeltaEvent:
+    AnnotationAddedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseAnnotationAddedEvent'
+        - type: object
+          properties: {}
+      description: Event emitted when a text annotation is added to output
+      example:
+        type: response.output_text.annotation.added
+        output_index: 0
+        item_id: item-1
+        content_index: 0
+        sequence_number: 5
+        annotation_index: 0
+        annotation:
+          type: url_citation
+          url: https://example.com
+          title: Example
+          start_index: 0
+          end_index: 7
+    BaseFunctionCallArgsDeltaEvent:
       type: object
       properties:
         type:
@@ -2041,11 +2915,11 @@ components:
         item_id:
           type: string
         output_index:
-          type: number
+          type: integer
         delta:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - item_id
@@ -2059,7 +2933,19 @@ components:
         output_index: 0
         delta: '{"city": "San'
         sequence_number: 4
-    OpenResponsesFunctionCallArgumentsDoneEvent:
+    FunctionCallArgsDeltaEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseFunctionCallArgsDeltaEvent'
+        - type: object
+          properties: {}
+      description: Event emitted when function call arguments are being streamed
+      example:
+        type: response.function_call_arguments.delta
+        item_id: item-1
+        output_index: 0
+        delta: '{"city": "San'
+        sequence_number: 4
+    BaseFunctionCallArgsDoneEvent:
       type: object
       properties:
         type:
@@ -2069,13 +2955,13 @@ components:
         item_id:
           type: string
         output_index:
-          type: number
+          type: integer
         name:
           type: string
         arguments:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - item_id
@@ -2091,7 +2977,20 @@ components:
         name: get_weather
         arguments: '{"city": "San Francisco", "units": "celsius"}'
         sequence_number: 6
-    OpenAIResponsesReasoningDeltaEvent:
+    FunctionCallArgsDoneEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseFunctionCallArgsDoneEvent'
+        - type: object
+          properties: {}
+      description: Event emitted when function call arguments streaming is complete
+      example:
+        type: response.function_call_arguments.done
+        item_id: item-1
+        output_index: 0
+        name: get_weather
+        arguments: '{"city": "San Francisco", "units": "celsius"}'
+        sequence_number: 6
+    BaseReasoningDeltaEvent:
       type: object
       properties:
         type:
@@ -2099,15 +2998,15 @@ components:
           enum:
             - response.reasoning_text.delta
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         delta:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -2123,9 +3022,9 @@ components:
         content_index: 0
         delta: First, we need
         sequence_number: 4
-    OpenResponsesReasoningDeltaEvent:
+    ReasoningDeltaEvent:
       allOf:
-        - $ref: '#/components/schemas/OpenAIResponsesReasoningDeltaEvent'
+        - $ref: '#/components/schemas/BaseReasoningDeltaEvent'
         - type: object
           properties: {}
       description: Event emitted when reasoning text delta is streamed
@@ -2136,7 +3035,7 @@ components:
         content_index: 0
         delta: First, we need
         sequence_number: 4
-    OpenAIResponsesReasoningDoneEvent:
+    BaseReasoningDoneEvent:
       type: object
       properties:
         type:
@@ -2144,15 +3043,15 @@ components:
           enum:
             - response.reasoning_text.done
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         content_index:
-          type: number
+          type: integer
         text:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -2168,9 +3067,9 @@ components:
         content_index: 0
         text: First, we need to identify the key components and then combine them logically.
         sequence_number: 6
-    OpenResponsesReasoningDoneEvent:
+    ReasoningDoneEvent:
       allOf:
-        - $ref: '#/components/schemas/OpenAIResponsesReasoningDoneEvent'
+        - $ref: '#/components/schemas/BaseReasoningDoneEvent'
         - type: object
           properties: {}
       description: Event emitted when reasoning text streaming is complete
@@ -2181,7 +3080,7 @@ components:
         content_index: 0
         text: First, we need to identify the key components and then combine them logically.
         sequence_number: 6
-    OpenAIResponsesReasoningSummaryPartAddedEvent:
+    BaseReasoningSummaryPartAddedEvent:
       type: object
       properties:
         type:
@@ -2189,15 +3088,15 @@ components:
           enum:
             - response.reasoning_summary_part.added
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         summary_index:
-          type: number
+          type: integer
         part:
           $ref: '#/components/schemas/ReasoningSummaryText'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -2215,9 +3114,9 @@ components:
           type: summary_text
           text: ''
         sequence_number: 3
-    OpenResponsesReasoningSummaryPartAddedEvent:
+    ReasoningSummaryPartAddedEvent:
       allOf:
-        - $ref: '#/components/schemas/OpenAIResponsesReasoningSummaryPartAddedEvent'
+        - $ref: '#/components/schemas/BaseReasoningSummaryPartAddedEvent'
         - type: object
           properties: {}
       description: Event emitted when a reasoning summary part is added
@@ -2230,7 +3129,7 @@ components:
           type: summary_text
           text: ''
         sequence_number: 3
-    OpenResponsesReasoningSummaryPartDoneEvent:
+    BaseReasoningSummaryPartDoneEvent:
       type: object
       properties:
         type:
@@ -2238,15 +3137,15 @@ components:
           enum:
             - response.reasoning_summary_part.done
         output_index:
-          type: number
+          type: integer
         item_id:
           type: string
         summary_index:
-          type: number
+          type: integer
         part:
           $ref: '#/components/schemas/ReasoningSummaryText'
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - output_index
@@ -2264,7 +3163,22 @@ components:
           type: summary_text
           text: Analyzing the problem step by step to find the optimal solution.
         sequence_number: 7
-    OpenAIResponsesReasoningSummaryTextDeltaEvent:
+    ReasoningSummaryPartDoneEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseReasoningSummaryPartDoneEvent'
+        - type: object
+          properties: {}
+      description: Event emitted when a reasoning summary part is complete
+      example:
+        type: response.reasoning_summary_part.done
+        output_index: 0
+        item_id: item-1
+        summary_index: 0
+        part:
+          type: summary_text
+          text: Analyzing the problem step by step to find the optimal solution.
+        sequence_number: 7
+    BaseReasoningSummaryTextDeltaEvent:
       type: object
       properties:
         type:
@@ -2274,13 +3188,13 @@ components:
         item_id:
           type: string
         output_index:
-          type: number
+          type: integer
         summary_index:
-          type: number
+          type: integer
         delta:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - item_id
@@ -2296,9 +3210,9 @@ components:
         summary_index: 0
         delta: Analyzing
         sequence_number: 4
-    OpenResponsesReasoningSummaryTextDeltaEvent:
+    ReasoningSummaryTextDeltaEvent:
       allOf:
-        - $ref: '#/components/schemas/OpenAIResponsesReasoningSummaryTextDeltaEvent'
+        - $ref: '#/components/schemas/BaseReasoningSummaryTextDeltaEvent'
         - type: object
           properties: {}
       description: Event emitted when reasoning summary text delta is streamed
@@ -2309,7 +3223,7 @@ components:
         summary_index: 0
         delta: Analyzing
         sequence_number: 4
-    OpenAIResponsesReasoningSummaryTextDoneEvent:
+    BaseReasoningSummaryTextDoneEvent:
       type: object
       properties:
         type:
@@ -2319,13 +3233,13 @@ components:
         item_id:
           type: string
         output_index:
-          type: number
+          type: integer
         summary_index:
-          type: number
+          type: integer
         text:
           type: string
         sequence_number:
-          type: number
+          type: integer
       required:
         - type
         - item_id
@@ -2341,9 +3255,9 @@ components:
         summary_index: 0
         text: Analyzing the problem step by step to find the optimal solution.
         sequence_number: 6
-    OpenResponsesReasoningSummaryTextDoneEvent:
+    ReasoningSummaryTextDoneEvent:
       allOf:
-        - $ref: '#/components/schemas/OpenAIResponsesReasoningSummaryTextDoneEvent'
+        - $ref: '#/components/schemas/BaseReasoningSummaryTextDoneEvent'
         - type: object
           properties: {}
       description: Event emitted when reasoning summary text streaming is complete
@@ -2372,7 +3286,7 @@ components:
         - item_id
         - output_index
         - sequence_number
-    OpenResponsesImageGenCallInProgress:
+    ImageGenCallInProgressEvent:
       allOf:
         - $ref: '#/components/schemas/OpenAIResponsesImageGenCallInProgress'
         - type: object
@@ -2401,7 +3315,7 @@ components:
         - item_id
         - output_index
         - sequence_number
-    OpenResponsesImageGenCallGenerating:
+    ImageGenCallGeneratingEvent:
       allOf:
         - $ref: '#/components/schemas/OpenAIResponsesImageGenCallGenerating'
         - type: object
@@ -2436,7 +3350,7 @@ components:
         - sequence_number
         - partial_image_b64
         - partial_image_index
-    OpenResponsesImageGenCallPartialImage:
+    ImageGenCallPartialImageEvent:
       allOf:
         - $ref: '#/components/schemas/OpenAIResponsesImageGenCallPartialImage'
         - type: object
@@ -2467,7 +3381,7 @@ components:
         - item_id
         - output_index
         - sequence_number
-    OpenResponsesImageGenCallCompleted:
+    ImageGenCallCompletedEvent:
       allOf:
         - $ref: '#/components/schemas/OpenAIResponsesImageGenCallCompleted'
         - type: object
@@ -2478,14 +3392,101 @@ components:
         output_index: 0
         sequence_number: 4
         item_id: call-123
-    OpenResponsesStreamEvent:
+    OpenAIResponsesWebSearchCallInProgress:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - response.web_search_call.in_progress
+        item_id:
+          type: string
+        output_index:
+          type: number
+        sequence_number:
+          type: number
+      required:
+        - type
+        - item_id
+        - output_index
+        - sequence_number
+    WebSearchCallInProgressEvent:
+      allOf:
+        - $ref: '#/components/schemas/OpenAIResponsesWebSearchCallInProgress'
+        - type: object
+          properties: {}
+      description: Web search call in progress
+      example:
+        type: response.web_search_call.in_progress
+        output_index: 0
+        sequence_number: 1
+        item_id: ws-123
+    OpenAIResponsesWebSearchCallSearching:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - response.web_search_call.searching
+        item_id:
+          type: string
+        output_index:
+          type: number
+        sequence_number:
+          type: number
+      required:
+        - type
+        - item_id
+        - output_index
+        - sequence_number
+    WebSearchCallSearchingEvent:
+      allOf:
+        - $ref: '#/components/schemas/OpenAIResponsesWebSearchCallSearching'
+        - type: object
+          properties: {}
+      description: Web search call is searching
+      example:
+        type: response.web_search_call.searching
+        output_index: 0
+        sequence_number: 2
+        item_id: ws-123
+    OpenAIResponsesSearchCompleted:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - response.web_search_call.completed
+        item_id:
+          type: string
+        output_index:
+          type: number
+        sequence_number:
+          type: number
+      required:
+        - type
+        - item_id
+        - output_index
+        - sequence_number
+    WebSearchCallCompletedEvent:
+      allOf:
+        - $ref: '#/components/schemas/OpenAIResponsesSearchCompleted'
+        - type: object
+          properties: {}
+      description: Web search call completed
+      example:
+        type: response.web_search_call.completed
+        output_index: 0
+        sequence_number: 3
+        item_id: ws-123
+    StreamEvents:
       oneOf:
         - allOf:
-            - $ref: '#/components/schemas/OpenResponsesCreatedEvent'
+            - $ref: '#/components/schemas/CreatedEvent'
             - type: object
               properties:
                 response:
-                  $ref: '#/components/schemas/OpenResponsesNonStreamingResponse'
+                  $ref: '#/components/schemas/OpenResponsesResult'
           description: Event emitted when a response is created
           example:
             type: response.created
@@ -2508,11 +3509,11 @@ components:
               max_output_tokens: null
             sequence_number: 0
         - allOf:
-            - $ref: '#/components/schemas/OpenResponsesInProgressEvent'
+            - $ref: '#/components/schemas/InProgressEvent'
             - type: object
               properties:
                 response:
-                  $ref: '#/components/schemas/OpenResponsesNonStreamingResponse'
+                  $ref: '#/components/schemas/OpenResponsesResult'
           description: Event emitted when a response is in progress
           example:
             type: response.in_progress
@@ -2535,11 +3536,11 @@ components:
               max_output_tokens: null
             sequence_number: 1
         - allOf:
-            - $ref: '#/components/schemas/OpenResponsesCompletedEvent'
+            - $ref: '#/components/schemas/CompletedEvent'
             - type: object
               properties:
                 response:
-                  $ref: '#/components/schemas/OpenResponsesNonStreamingResponse'
+                  $ref: '#/components/schemas/OpenResponsesResult'
           description: Event emitted when a response has completed successfully
           example:
             type: response.completed
@@ -2570,11 +3571,11 @@ components:
               max_output_tokens: null
             sequence_number: 10
         - allOf:
-            - $ref: '#/components/schemas/OpenResponsesIncompleteEvent'
+            - $ref: '#/components/schemas/IncompleteEvent'
             - type: object
               properties:
                 response:
-                  $ref: '#/components/schemas/OpenResponsesNonStreamingResponse'
+                  $ref: '#/components/schemas/OpenResponsesResult'
           description: Event emitted when a response is incomplete
           example:
             type: response.incomplete
@@ -2597,11 +3598,11 @@ components:
               max_output_tokens: null
             sequence_number: 5
         - allOf:
-            - $ref: '#/components/schemas/OpenResponsesFailedEvent'
+            - $ref: '#/components/schemas/FailedEvent'
             - type: object
               properties:
                 response:
-                  $ref: '#/components/schemas/OpenResponsesNonStreamingResponse'
+                  $ref: '#/components/schemas/OpenResponsesResult'
           description: Event emitted when a response has failed
           example:
             type: response.failed
@@ -2623,13 +3624,13 @@ components:
               top_p: null
               max_output_tokens: null
             sequence_number: 3
-        - $ref: '#/components/schemas/OpenResponsesErrorEvent'
+        - $ref: '#/components/schemas/ErrorEvent'
         - allOf:
-            - $ref: '#/components/schemas/OpenResponsesOutputItemAddedEvent'
+            - $ref: '#/components/schemas/OutputItemAddedEvent'
             - type: object
               properties:
                 item:
-                  $ref: '#/components/schemas/ResponsesOutputItem'
+                  $ref: '#/components/schemas/OutputItems'
           description: Event emitted when a new output item is added to the response
           example:
             type: response.output_item.added
@@ -2642,11 +3643,11 @@ components:
               content: []
             sequence_number: 2
         - allOf:
-            - $ref: '#/components/schemas/OpenResponsesOutputItemDoneEvent'
+            - $ref: '#/components/schemas/OutputItemDoneEvent'
             - type: object
               properties:
                 item:
-                  $ref: '#/components/schemas/ResponsesOutputItem'
+                  $ref: '#/components/schemas/OutputItems'
           description: Event emitted when an output item is complete
           example:
             type: response.output_item.done
@@ -2661,160 +3662,28 @@ components:
                   text: Hello! How can I help you?
                   annotations: []
             sequence_number: 8
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesContentPartAddedEvent'
-            - type: object
-              properties:
-                part:
-                  anyOf:
-                    - $ref: '#/components/schemas/ResponseOutputText'
-                    - $ref: '#/components/schemas/ReasoningTextContent'
-                    - $ref: '#/components/schemas/OpenAIResponsesRefusalContent'
-          description: Event emitted when a new content part is added to an output item
-          example:
-            type: response.content_part.added
-            output_index: 0
-            item_id: item-1
-            content_index: 0
-            part:
-              type: output_text
-              text: ''
-              annotations: []
-            sequence_number: 3
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesContentPartDoneEvent'
-            - type: object
-              properties:
-                part:
-                  anyOf:
-                    - $ref: '#/components/schemas/ResponseOutputText'
-                    - $ref: '#/components/schemas/ReasoningTextContent'
-                    - $ref: '#/components/schemas/OpenAIResponsesRefusalContent'
-          description: Event emitted when a content part is complete
-          example:
-            type: response.content_part.done
-            output_index: 0
-            item_id: item-1
-            content_index: 0
-            part:
-              type: output_text
-              text: Hello! How can I help you?
-              annotations: []
-            sequence_number: 7
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesTextDeltaEvent'
-            - type: object
-              properties: {}
-          description: Event emitted when a text delta is streamed
-          example:
-            type: response.output_text.delta
-            logprobs: []
-            output_index: 0
-            item_id: item-1
-            content_index: 0
-            delta: Hello
-            sequence_number: 4
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesTextDoneEvent'
-            - type: object
-              properties: {}
-          description: Event emitted when text streaming is complete
-          example:
-            type: response.output_text.done
-            output_index: 0
-            item_id: item-1
-            content_index: 0
-            text: Hello! How can I help you?
-            sequence_number: 6
-            logprobs: []
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesRefusalDeltaEvent'
-            - type: object
-              properties: {}
-          description: Event emitted when a refusal delta is streamed
-          example:
-            type: response.refusal.delta
-            output_index: 0
-            item_id: item-1
-            content_index: 0
-            delta: I'm sorry
-            sequence_number: 4
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesRefusalDoneEvent'
-            - type: object
-              properties: {}
-          description: Event emitted when refusal streaming is complete
-          example:
-            type: response.refusal.done
-            output_index: 0
-            item_id: item-1
-            content_index: 0
-            refusal: I'm sorry, but I can't assist with that request.
-            sequence_number: 6
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesOutputTextAnnotationAddedEvent'
-            - type: object
-              properties: {}
-          description: Event emitted when a text annotation is added to output
-          example:
-            type: response.output_text.annotation.added
-            output_index: 0
-            item_id: item-1
-            content_index: 0
-            sequence_number: 5
-            annotation_index: 0
-            annotation:
-              type: url_citation
-              url: https://example.com
-              title: Example
-              start_index: 0
-              end_index: 7
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesFunctionCallArgumentsDeltaEvent'
-            - type: object
-              properties: {}
-          description: Event emitted when function call arguments are being streamed
-          example:
-            type: response.function_call_arguments.delta
-            item_id: item-1
-            output_index: 0
-            delta: '{"city": "San'
-            sequence_number: 4
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesFunctionCallArgumentsDoneEvent'
-            - type: object
-              properties: {}
-          description: Event emitted when function call arguments streaming is complete
-          example:
-            type: response.function_call_arguments.done
-            item_id: item-1
-            output_index: 0
-            name: get_weather
-            arguments: '{"city": "San Francisco", "units": "celsius"}'
-            sequence_number: 6
-        - $ref: '#/components/schemas/OpenResponsesReasoningDeltaEvent'
-        - $ref: '#/components/schemas/OpenResponsesReasoningDoneEvent'
-        - $ref: '#/components/schemas/OpenResponsesReasoningSummaryPartAddedEvent'
-        - allOf:
-            - $ref: '#/components/schemas/OpenResponsesReasoningSummaryPartDoneEvent'
-            - type: object
-              properties: {}
-          description: Event emitted when a reasoning summary part is complete
-          example:
-            type: response.reasoning_summary_part.done
-            output_index: 0
-            item_id: item-1
-            summary_index: 0
-            part:
-              type: summary_text
-              text: Analyzing the problem step by step to find the optimal solution.
-            sequence_number: 7
-        - $ref: '#/components/schemas/OpenResponsesReasoningSummaryTextDeltaEvent'
-        - $ref: '#/components/schemas/OpenResponsesReasoningSummaryTextDoneEvent'
-        - $ref: '#/components/schemas/OpenResponsesImageGenCallInProgress'
-        - $ref: '#/components/schemas/OpenResponsesImageGenCallGenerating'
-        - $ref: '#/components/schemas/OpenResponsesImageGenCallPartialImage'
-        - $ref: '#/components/schemas/OpenResponsesImageGenCallCompleted'
+        - $ref: '#/components/schemas/ContentPartAddedEvent'
+        - $ref: '#/components/schemas/ContentPartDoneEvent'
+        - $ref: '#/components/schemas/TextDeltaEvent'
+        - $ref: '#/components/schemas/TextDoneEvent'
+        - $ref: '#/components/schemas/RefusalDeltaEvent'
+        - $ref: '#/components/schemas/RefusalDoneEvent'
+        - $ref: '#/components/schemas/AnnotationAddedEvent'
+        - $ref: '#/components/schemas/FunctionCallArgsDeltaEvent'
+        - $ref: '#/components/schemas/FunctionCallArgsDoneEvent'
+        - $ref: '#/components/schemas/ReasoningDeltaEvent'
+        - $ref: '#/components/schemas/ReasoningDoneEvent'
+        - $ref: '#/components/schemas/ReasoningSummaryPartAddedEvent'
+        - $ref: '#/components/schemas/ReasoningSummaryPartDoneEvent'
+        - $ref: '#/components/schemas/ReasoningSummaryTextDeltaEvent'
+        - $ref: '#/components/schemas/ReasoningSummaryTextDoneEvent'
+        - $ref: '#/components/schemas/ImageGenCallInProgressEvent'
+        - $ref: '#/components/schemas/ImageGenCallGeneratingEvent'
+        - $ref: '#/components/schemas/ImageGenCallPartialImageEvent'
+        - $ref: '#/components/schemas/ImageGenCallCompletedEvent'
+        - $ref: '#/components/schemas/WebSearchCallInProgressEvent'
+        - $ref: '#/components/schemas/WebSearchCallSearchingEvent'
+        - $ref: '#/components/schemas/WebSearchCallCompletedEvent'
       description: Union of all possible event types emitted during response streaming
       example:
         type: response.created
@@ -3278,11 +4147,16 @@ components:
         error:
           code: 529
           message: Provider returned error
-    OpenResponsesReasoning:
+    ReasoningItem:
       allOf:
         - $ref: '#/components/schemas/OutputItemReasoning'
         - type: object
           properties:
+            content:
+              type: array
+              nullable: true
+              items:
+                $ref: '#/components/schemas/ReasoningTextContent'
             signature:
               type: string
               nullable: true
@@ -3303,7 +4177,7 @@ components:
           - type: summary_text
             text: Step by step analysis
       description: Reasoning output item with signature and format extensions
-    ResponseInputVideo:
+    InputVideo:
       type: object
       properties:
         type:
@@ -3320,7 +4194,7 @@ components:
       example:
         type: input_video
         video_url: https://example.com/video.mp4
-    OpenResponsesEasyInputMessage:
+    EasyInputMessage:
       type: object
       properties:
         type:
@@ -3346,9 +4220,9 @@ components:
             - type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/ResponseInputText'
+                  - $ref: '#/components/schemas/InputText'
                   - allOf:
-                      - $ref: '#/components/schemas/ResponseInputImage'
+                      - $ref: '#/components/schemas/InputImage'
                       - type: object
                         properties: {}
                     description: Image input content item
@@ -3356,14 +4230,28 @@ components:
                       type: input_image
                       detail: auto
                       image_url: https://example.com/image.jpg
-                  - $ref: '#/components/schemas/ResponseInputFile'
-                  - $ref: '#/components/schemas/ResponseInputAudio'
-                  - $ref: '#/components/schemas/ResponseInputVideo'
+                  - $ref: '#/components/schemas/InputFile'
+                  - $ref: '#/components/schemas/InputAudio'
+                  - $ref: '#/components/schemas/InputVideo'
             - type: string
+            - nullable: true
+        phase:
+          anyOf:
+            - type: string
+              enum:
+                - commentary
+            - type: string
+              enum:
+                - final_answer
+            - nullable: true
+          description: >-
+            The phase of an assistant message. Use `commentary` for an intermediate assistant message and `final_answer`
+            for the final assistant message. For follow-up requests with models like `gpt-5.3-codex` and later, preserve
+            and resend phase on all assistant messages. Omitting it can degrade performance. Not used for user messages.
+          example: final_answer
       required:
         - role
-        - content
-    OpenResponsesInputMessageItem:
+    InputMessageItem:
       type: object
       properties:
         id:
@@ -3385,11 +4273,12 @@ components:
                 - developer
         content:
           type: array
+          nullable: true
           items:
             oneOf:
-              - $ref: '#/components/schemas/ResponseInputText'
+              - $ref: '#/components/schemas/InputText'
               - allOf:
-                  - $ref: '#/components/schemas/ResponseInputImage'
+                  - $ref: '#/components/schemas/InputImage'
                   - type: object
                     properties: {}
                 description: Image input content item
@@ -3397,13 +4286,12 @@ components:
                   type: input_image
                   detail: auto
                   image_url: https://example.com/image.jpg
-              - $ref: '#/components/schemas/ResponseInputFile'
-              - $ref: '#/components/schemas/ResponseInputAudio'
-              - $ref: '#/components/schemas/ResponseInputVideo'
+              - $ref: '#/components/schemas/InputFile'
+              - $ref: '#/components/schemas/InputAudio'
+              - $ref: '#/components/schemas/InputVideo'
       required:
         - role
-        - content
-    OpenResponsesFunctionToolCall:
+    FunctionCallItem:
       type: object
       properties:
         type:
@@ -3419,7 +4307,7 @@ components:
         id:
           type: string
         status:
-          $ref: '#/components/schemas/ToolCallStatus'
+          $ref: '#/components/schemas/ToolCallStatusEnum'
       required:
         - type
         - call_id
@@ -3434,7 +4322,7 @@ components:
         name: get_weather
         arguments: '{"location":"San Francisco"}'
         status: completed
-    OpenResponsesFunctionCallOutput:
+    FunctionCallOutputItem:
       type: object
       properties:
         type:
@@ -3447,9 +4335,24 @@ components:
         call_id:
           type: string
         output:
-          type: string
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                oneOf:
+                  - $ref: '#/components/schemas/InputText'
+                  - allOf:
+                      - $ref: '#/components/schemas/InputImage'
+                      - type: object
+                        properties: {}
+                    description: Image input content item
+                    example:
+                      type: input_image
+                      detail: auto
+                      image_url: https://example.com/image.jpg
+                  - $ref: '#/components/schemas/InputFile'
         status:
-          $ref: '#/components/schemas/ToolCallStatus'
+          $ref: '#/components/schemas/ToolCallStatusEnum'
       required:
         - type
         - call_id
@@ -3461,30 +4364,156 @@ components:
         call_id: call-abc123
         output: '{"temperature":72,"conditions":"sunny"}'
         status: completed
-    OpenResponsesInput:
+    OutputDatetimeItem:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - openrouter:datetime
+        id:
+          type: string
+        status:
+          type: string
+          enum:
+            - completed
+            - in_progress
+            - incomplete
+        datetime:
+          type: string
+          description: ISO 8601 datetime string
+        timezone:
+          type: string
+          description: IANA timezone name
+      required:
+        - type
+        - status
+        - datetime
+        - timezone
+      description: An openrouter:datetime server tool output item
+      example:
+        type: openrouter:datetime
+        id: dt_tmp_abc123
+        status: completed
+        datetime: '2026-03-12T14:30:00.000Z'
+        timezone: UTC
+    Inputs:
       anyOf:
         - type: string
         - type: array
           items:
             anyOf:
-              - $ref: '#/components/schemas/OpenResponsesReasoning'
-              - $ref: '#/components/schemas/OpenResponsesEasyInputMessage'
-              - $ref: '#/components/schemas/OpenResponsesInputMessageItem'
-              - $ref: '#/components/schemas/OpenResponsesFunctionToolCall'
-              - $ref: '#/components/schemas/OpenResponsesFunctionCallOutput'
-              - $ref: '#/components/schemas/ResponsesOutputMessage'
-              - $ref: '#/components/schemas/ResponsesOutputItemReasoning'
-              - $ref: '#/components/schemas/ResponsesOutputItemFunctionCall'
-              - $ref: '#/components/schemas/ResponsesWebSearchCallOutput'
-              - $ref: '#/components/schemas/ResponsesOutputItemFileSearchCall'
-              - $ref: '#/components/schemas/ResponsesImageGenerationCall'
+              - $ref: '#/components/schemas/ReasoningItem'
+              - $ref: '#/components/schemas/EasyInputMessage'
+              - $ref: '#/components/schemas/InputMessageItem'
+              - $ref: '#/components/schemas/FunctionCallItem'
+              - $ref: '#/components/schemas/FunctionCallOutputItem'
+              - allOf:
+                  - $ref: '#/components/schemas/OutputMessageItem'
+                  - type: object
+                    properties:
+                      content:
+                        anyOf:
+                          - type: array
+                            items:
+                              anyOf:
+                                - $ref: '#/components/schemas/ResponseOutputText'
+                                - $ref: '#/components/schemas/OpenAIResponsesRefusalContent'
+                          - type: string
+                          - nullable: true
+                example:
+                  id: msg-123
+                  type: message
+                  role: assistant
+                  status: completed
+                  content:
+                    - type: output_text
+                      text: Hello! How can I help you?
+                      annotations: []
+                description: An output message item
+              - allOf:
+                  - $ref: '#/components/schemas/OutputReasoningItem'
+                  - type: object
+                    properties:
+                      summary:
+                        type: array
+                        nullable: true
+                        items:
+                          $ref: '#/components/schemas/ReasoningSummaryText'
+                example:
+                  id: reasoning-123
+                  type: reasoning
+                  status: completed
+                  summary:
+                    - type: summary_text
+                      text: Analyzed the problem and found the optimal solution.
+                  content:
+                    - type: reasoning_text
+                      text: First, we analyze the problem...
+                  signature: EvcBCkgIChABGAIqQKkSDbRuVEQUk9qN1odC098l9SEj...
+                  format: anthropic-claude-v1
+                description: An output item containing reasoning
+              - $ref: '#/components/schemas/OutputFunctionCallItem'
+              - $ref: '#/components/schemas/OutputWebSearchCallItem'
+              - $ref: '#/components/schemas/OutputFileSearchCallItem'
+              - $ref: '#/components/schemas/OutputImageGenerationCallItem'
+              - $ref: '#/components/schemas/OutputDatetimeItem'
+              - $ref: '#/components/schemas/OutputServerToolItem'
       description: Input for a response request - can be a string or array of items
       example:
         - role: user
           content: What is the weather today?
-    OpenResponsesResponseText:
+    DatetimeServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - openrouter:datetime
+        parameters:
+          type: object
+          properties:
+            timezone:
+              type: string
+              description: IANA timezone name (e.g. "America/New_York"). Defaults to UTC.
+              example: America/New_York
+      required:
+        - type
+      description: 'OpenRouter built-in server tool: returns the current date and time'
+      example:
+        type: openrouter:datetime
+        parameters:
+          timezone: America/New_York
+    WebSearchServerTool_OpenRouter:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - openrouter:web_search
+        parameters:
+          type: object
+          properties:
+            max_results:
+              type: integer
+              description: Maximum number of search results to return per search call. Defaults to 5.
+              example: 5
+            max_total_results:
+              type: integer
+              description: >-
+                Maximum total number of search results across all search calls in a single request. Once this limit is
+                reached, the tool will stop returning new results.
+              example: 20
+      required:
+        - type
+      description: 'OpenRouter built-in server tool: searches the web for current information'
+      example:
+        type: openrouter:web_search
+        parameters:
+          max_results: 5
+    TextExtendedConfig:
       allOf:
-        - $ref: '#/components/schemas/ResponseTextConfig'
+        - $ref: '#/components/schemas/TextConfig'
         - type: object
           properties: {}
       description: Text output configuration including format and verbosity
@@ -3492,15 +4521,14 @@ components:
         format:
           type: text
         verbosity: medium
-    OpenResponsesReasoningConfig:
+    ReasoningConfig:
       allOf:
-        - $ref: '#/components/schemas/OpenAIResponsesReasoningConfig'
+        - $ref: '#/components/schemas/BaseReasoningConfig'
         - type: object
           nullable: true
           properties:
             max_tokens:
-              type: number
-              nullable: true
+              type: integer
             enabled:
               type: boolean
               nullable: true
@@ -3508,12 +4536,12 @@ components:
       example:
         summary: auto
         enabled: true
-    ResponsesOutputModality:
+    OutputModalityEnum:
       type: string
       enum:
         - text
         - image
-    OpenAIResponsesIncludable:
+    ResponseIncludesEnum:
       type: string
       enum:
         - file_search_call.results
@@ -3521,6 +4549,13 @@ components:
         - computer_call_output.output.image_url
         - reasoning.encrypted_content
         - code_interpreter_call.outputs
+    OpenAIResponsesTruncation:
+      type: string
+      nullable: true
+      enum:
+        - auto
+        - disabled
+      example: auto
     DataCollection:
       type: string
       nullable: true
@@ -3539,9 +4574,11 @@ components:
     ProviderName:
       type: string
       enum:
+        - AkashML
         - AI21
         - AionLabs
         - Alibaba
+        - Ambient
         - Amazon Bedrock
         - Amazon Nova
         - Anthropic
@@ -3572,7 +4609,9 @@ components:
         - Inception
         - Inceptron
         - InferenceNet
+        - Ionstream
         - Infermatic
+        - Io Net
         - Inflection
         - Liquid
         - Mara
@@ -3593,11 +4632,13 @@ components:
         - Parasail
         - Perplexity
         - Phala
+        - Reka
         - Relace
         - SambaNova
         - Seed
         - SiliconFlow
         - Sourceful
+        - StepFun
         - Stealth
         - StreamLake
         - Switchpoint
@@ -3629,23 +4670,39 @@ components:
         - price
         - throughput
         - latency
+        - exacto
+      description: The provider sorting strategy (price, throughput, latency)
+      example: price
     ProviderSortConfig:
       type: object
       properties:
         by:
-          anyOf:
-            - $ref: '#/components/schemas/ProviderSort'
-            - type: 'null'
+          type: string
+          nullable: true
+          enum:
+            - price
+            - throughput
+            - latency
+            - exacto
+          description: The provider sorting strategy (price, throughput, latency)
+          example: price
         partition:
-          anyOf:
-            - type: string
-              enum:
-                - model
-                - none
-            - type: 'null'
+          type: string
+          nullable: true
+          enum:
+            - model
+            - none
+          description: >-
+            Partitioning strategy for sorting: "model" (default) groups endpoints by model before sorting (fallback
+            models remain fallbacks), "none" sorts all endpoints together regardless of model.
+          example: model
+      description: The provider sorting strategy (price, throughput, latency)
+      example:
+        by: price
+        partition: model
     BigNumberUnion:
       type: string
-      description: A value in string format that is a large number
+      description: Price per million prompt tokens
       example: 1000
     PercentileThroughputCutoffs:
       type: object
@@ -3720,36 +4777,49 @@ components:
       enum:
         - native
         - exa
+        - firecrawl
+        - parallel
       description: The search engine to use for web search.
     PDFParserEngine:
-      type: string
-      enum:
-        - mistral-ocr
-        - pdf-text
-        - native
-      description: The engine to use for parsing PDF files.
+      anyOf:
+        - type: string
+          enum:
+            - mistral-ocr
+            - native
+            - cloudflare-ai
+        - type: string
+          enum:
+            - pdf-text
+      description: >-
+        The engine to use for parsing PDF files. "pdf-text" is deprecated and automatically redirected to
+        "cloudflare-ai".
     PDFParserOptions:
       type: object
       properties:
         engine:
           $ref: '#/components/schemas/PDFParserEngine'
       description: Options for PDF parsing.
-    OpenResponsesRequest:
+    ContextCompressionEngine:
+      type: string
+      enum:
+        - middle-out
+      description: The compression engine to use. Defaults to "middle-out".
+    ResponsesRequest:
       type: object
       properties:
         input:
-          $ref: '#/components/schemas/OpenResponsesInput'
+          $ref: '#/components/schemas/Inputs'
         instructions:
           type: string
           nullable: true
         metadata:
-          $ref: '#/components/schemas/OpenResponsesRequestMetadata'
+          $ref: '#/components/schemas/RequestMetadata'
         tools:
           type: array
           items:
-            oneOf:
+            anyOf:
               - allOf:
-                  - $ref: '#/components/schemas/OpenResponsesFunctionTool'
+                  - $ref: '#/components/schemas/FunctionTool'
                   - type: object
                     properties: {}
                 description: Function tool definition
@@ -3770,10 +4840,21 @@ components:
                           - fahrenheit
                     required:
                       - location
-              - $ref: '#/components/schemas/OpenResponsesWebSearchPreviewTool'
-              - $ref: '#/components/schemas/OpenResponsesWebSearchPreview20250311Tool'
-              - $ref: '#/components/schemas/OpenResponsesWebSearchTool'
-              - $ref: '#/components/schemas/OpenResponsesWebSearch20250826Tool'
+              - $ref: '#/components/schemas/Preview_WebSearchServerTool'
+              - $ref: '#/components/schemas/Preview_20250311_WebSearchServerTool'
+              - $ref: '#/components/schemas/Legacy_WebSearchServerTool'
+              - $ref: '#/components/schemas/WebSearchServerTool'
+              - $ref: '#/components/schemas/FileSearchServerTool'
+              - $ref: '#/components/schemas/ComputerUseServerTool'
+              - $ref: '#/components/schemas/CodeInterpreterServerTool'
+              - $ref: '#/components/schemas/McpServerTool'
+              - $ref: '#/components/schemas/ImageGenerationServerTool'
+              - $ref: '#/components/schemas/CodexLocalShellTool'
+              - $ref: '#/components/schemas/ShellServerTool'
+              - $ref: '#/components/schemas/ApplyPatchServerTool'
+              - $ref: '#/components/schemas/CustomTool'
+              - $ref: '#/components/schemas/DatetimeServerTool'
+              - $ref: '#/components/schemas/WebSearchServerTool_OpenRouter'
         tool_choice:
           $ref: '#/components/schemas/OpenAIResponsesToolChoice'
         parallel_tool_calls:
@@ -3786,47 +4867,36 @@ components:
           items:
             type: string
         text:
-          $ref: '#/components/schemas/OpenResponsesResponseText'
+          $ref: '#/components/schemas/TextExtendedConfig'
         reasoning:
-          $ref: '#/components/schemas/OpenResponsesReasoningConfig'
+          $ref: '#/components/schemas/ReasoningConfig'
         max_output_tokens:
-          type: number
-          nullable: true
+          type: integer
         temperature:
           type: number
-          nullable: true
-          minimum: 0
-          maximum: 2
+          format: double
         top_p:
           type: number
-          nullable: true
-          minimum: 0
+          format: double
         top_logprobs:
           type: integer
-          nullable: true
-          minimum: 0
-          maximum: 20
         max_tool_calls:
           type: integer
-          nullable: true
         presence_penalty:
           type: number
-          nullable: true
-          minimum: -2
-          maximum: 2
+          format: double
         frequency_penalty:
           type: number
-          nullable: true
-          minimum: -2
-          maximum: 2
+          format: double
         top_k:
-          type: number
+          type: integer
         image_config:
           type: object
           additionalProperties:
             anyOf:
               - type: string
               - type: number
+                format: double
           description: >-
             Provider-specific image configuration options. Keys and values vary by model/provider. See
             https://openrouter.ai/docs/features/multimodal/image-generation for more details.
@@ -3835,7 +4905,7 @@ components:
         modalities:
           type: array
           items:
-            $ref: '#/components/schemas/ResponsesOutputModality'
+            $ref: '#/components/schemas/OutputModalityEnum'
           description: Output modalities for the response. Supported values are "text" and "image".
           example:
             - text
@@ -3847,12 +4917,12 @@ components:
           type: string
           nullable: true
         prompt:
-          $ref: '#/components/schemas/OpenAIResponsesPrompt'
+          $ref: '#/components/schemas/StoredPromptTemplate'
         include:
           type: array
           nullable: true
           items:
-            $ref: '#/components/schemas/OpenAIResponsesIncludable'
+            $ref: '#/components/schemas/ResponseIncludesEnum'
         background:
           type: boolean
           nullable: true
@@ -3865,13 +4935,16 @@ components:
           default: false
         service_tier:
           type: string
+          nullable: true
           enum:
             - auto
+            - default
+            - flex
+            - priority
+            - scale
           default: auto
         truncation:
-          allOf:
-            - $ref: '#/components/schemas/OpenAIResponsesTruncation'
-            - example: auto
+          $ref: '#/components/schemas/OpenAIResponsesTruncation'
         stream:
           type: boolean
           default: false
@@ -3964,13 +5037,21 @@ components:
                 prompt:
                   $ref: '#/components/schemas/BigNumberUnion'
                 completion:
-                  $ref: '#/components/schemas/BigNumberUnion'
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per million completion tokens
                 image:
-                  $ref: '#/components/schemas/BigNumberUnion'
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per image
                 audio:
-                  $ref: '#/components/schemas/BigNumberUnion'
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per audio unit
                 request:
-                  $ref: '#/components/schemas/BigNumberUnion'
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per request
               description: >-
                 The object specifying the maximum price you want to pay for this request. USD price per million tokens,
                 for prompt and completion.
@@ -4030,6 +5111,28 @@ components:
                     type: string
                   engine:
                     $ref: '#/components/schemas/WebSearchEngine'
+                  include_domains:
+                    type: array
+                    items:
+                      type: string
+                    description: >-
+                      A list of domains to restrict web search results to. Supports wildcards (e.g. "*.substack.com")
+                      and path filtering (e.g. "openai.com/blog").
+                    example:
+                      - example.com
+                      - '*.substack.com'
+                      - openai.com/blog
+                  exclude_domains:
+                    type: array
+                    items:
+                      type: string
+                    description: >-
+                      A list of domains to exclude from web search results. Supports wildcards (e.g. "*.substack.com")
+                      and path filtering (e.g. "openai.com/blog").
+                    example:
+                      - example.com
+                      - '*.substack.com'
+                      - openai.com/blog
                 required:
                   - id
               - type: object
@@ -4056,6 +5159,19 @@ components:
                     description: Set to false to disable the response-healing plugin for this request. Defaults to true.
                 required:
                   - id
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - context-compression
+                  enabled:
+                    type: boolean
+                    description: Set to false to disable the context-compression plugin for this request. Defaults to true.
+                  engine:
+                    $ref: '#/components/schemas/ContextCompressionEngine'
+                required:
+                  - id
           description: Plugins you want to enable for this request, including their settings.
         route:
           type: string
@@ -4072,18 +5188,37 @@ components:
           x-fern-ignore: true
         user:
           type: string
-          maxLength: 128
+          maxLength: 256
           description: >-
             A unique identifier representing your end-user, which helps distinguish between different users of your app.
             This allows your app to identify specific users in case of abuse reports, preventing your entire app from
-            being affected by the actions of individual users. Maximum of 128 characters.
+            being affected by the actions of individual users. Maximum of 256 characters.
         session_id:
           type: string
-          maxLength: 128
+          maxLength: 256
           description: >-
             A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for
             observability. If provided in both the request body and the x-session-id header, the body value takes
-            precedence. Maximum of 128 characters.
+            precedence. Maximum of 256 characters.
+        trace:
+          type: object
+          properties:
+            trace_id:
+              type: string
+            trace_name:
+              type: string
+            span_name:
+              type: string
+            generation_name:
+              type: string
+            parent_span_id:
+              type: string
+          additionalProperties:
+            nullable: true
+          description: >-
+            Metadata for observability and tracing. Known keys (trace_id, trace_name, span_name, generation_name,
+            parent_span_id) have special handling. Additional keys are passed through as custom metadata to configured
+            broadcast destinations.
       description: Request schema for Responses endpoint
       example:
         model: anthropic/claude-4.5-sonnet-20250929
@@ -4102,7 +5237,7 @@ components:
               properties:
                 location:
                   type: string
-    BaseAnthropicMessagesResponse:
+    BaseMessagesResult:
       type: object
       properties:
         id:
@@ -4115,6 +5250,17 @@ components:
           type: string
           enum:
             - assistant
+        container:
+          type: object
+          nullable: true
+          properties:
+            id:
+              type: string
+            expires_at:
+              type: string
+          required:
+            - id
+            - expires_at
         content:
           type: array
           items:
@@ -4276,6 +5422,38 @@ components:
                       - tool_use
                   id:
                     type: string
+                  caller:
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - direct
+                        required:
+                          - type
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_20250825
+                          tool_id:
+                            type: string
+                        required:
+                          - type
+                          - tool_id
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_20260120
+                          tool_id:
+                            type: string
+                        required:
+                          - type
+                          - tool_id
                   name:
                     type: string
                   input:
@@ -4283,6 +5461,7 @@ components:
                 required:
                   - type
                   - id
+                  - caller
                   - name
               - type: object
                 properties:
@@ -4317,15 +5496,54 @@ components:
                       - server_tool_use
                   id:
                     type: string
+                  caller:
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - direct
+                        required:
+                          - type
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_20250825
+                          tool_id:
+                            type: string
+                        required:
+                          - type
+                          - tool_id
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_20260120
+                          tool_id:
+                            type: string
+                        required:
+                          - type
+                          - tool_id
                   name:
                     type: string
                     enum:
                       - web_search
+                      - web_fetch
+                      - code_execution
+                      - bash_code_execution
+                      - text_editor_code_execution
+                      - tool_search_tool_regex
+                      - tool_search_tool_bm25
                   input:
                     nullable: true
                 required:
                   - type
                   - id
+                  - caller
                   - name
               - type: object
                 properties:
@@ -4333,6 +5551,38 @@ components:
                     type: string
                     enum:
                       - web_search_tool_result
+                  caller:
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - direct
+                        required:
+                          - type
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_20250825
+                          tool_id:
+                            type: string
+                        required:
+                          - type
+                          - tool_id
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_20260120
+                          tool_id:
+                            type: string
+                        required:
+                          - type
+                          - tool_id
                   tool_use_id:
                     type: string
                   content:
@@ -4374,13 +5624,486 @@ components:
                               - max_uses_exceeded
                               - too_many_requests
                               - query_too_long
+                              - request_too_large
                         required:
                           - type
                           - error_code
                 required:
                   - type
+                  - caller
                   - tool_use_id
                   - content
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - web_fetch_tool_result
+                  caller:
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - direct
+                        required:
+                          - type
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_20250825
+                          tool_id:
+                            type: string
+                        required:
+                          - type
+                          - tool_id
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_20260120
+                          tool_id:
+                            type: string
+                        required:
+                          - type
+                          - tool_id
+                  content:
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - web_fetch_tool_result_error
+                          error_code:
+                            type: string
+                            enum:
+                              - invalid_tool_input
+                              - url_too_long
+                              - url_not_allowed
+                              - url_not_accessible
+                              - unsupported_content_type
+                              - too_many_requests
+                              - max_uses_exceeded
+                              - unavailable
+                        required:
+                          - type
+                          - error_code
+                      - type: object
+                        properties:
+                          content:
+                            type: object
+                            properties:
+                              citations:
+                                type: object
+                                nullable: true
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                required:
+                                  - enabled
+                              source:
+                                anyOf:
+                                  - type: object
+                                    properties:
+                                      data:
+                                        type: string
+                                      media_type:
+                                        type: string
+                                        enum:
+                                          - application/pdf
+                                      type:
+                                        type: string
+                                        enum:
+                                          - base64
+                                    required:
+                                      - data
+                                      - media_type
+                                      - type
+                                  - type: object
+                                    properties:
+                                      data:
+                                        type: string
+                                      media_type:
+                                        type: string
+                                        enum:
+                                          - text/plain
+                                      type:
+                                        type: string
+                                        enum:
+                                          - text
+                                    required:
+                                      - data
+                                      - media_type
+                                      - type
+                              title:
+                                type: string
+                                nullable: true
+                              type:
+                                type: string
+                                enum:
+                                  - document
+                            required:
+                              - citations
+                              - source
+                              - title
+                              - type
+                          retrieved_at:
+                            type: string
+                            nullable: true
+                          type:
+                            type: string
+                            enum:
+                              - web_fetch_result
+                          url:
+                            type: string
+                        required:
+                          - content
+                          - retrieved_at
+                          - type
+                          - url
+                  tool_use_id:
+                    type: string
+                required:
+                  - type
+                  - caller
+                  - content
+                  - tool_use_id
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - code_execution_tool_result
+                  content:
+                    oneOf:
+                      - type: object
+                        properties:
+                          error_code:
+                            type: string
+                            enum:
+                              - invalid_tool_input
+                              - unavailable
+                              - too_many_requests
+                              - execution_time_exceeded
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_tool_result_error
+                        required:
+                          - error_code
+                          - type
+                      - type: object
+                        properties:
+                          content:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                file_id:
+                                  type: string
+                                type:
+                                  type: string
+                                  enum:
+                                    - code_execution_output
+                              required:
+                                - file_id
+                                - type
+                          return_code:
+                            type: number
+                          stderr:
+                            type: string
+                          stdout:
+                            type: string
+                          type:
+                            type: string
+                            enum:
+                              - code_execution_result
+                        required:
+                          - content
+                          - return_code
+                          - stderr
+                          - stdout
+                          - type
+                      - type: object
+                        properties:
+                          content:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                file_id:
+                                  type: string
+                                type:
+                                  type: string
+                                  enum:
+                                    - code_execution_output
+                              required:
+                                - file_id
+                                - type
+                          encrypted_stdout:
+                            type: string
+                          return_code:
+                            type: number
+                          stderr:
+                            type: string
+                          type:
+                            type: string
+                            enum:
+                              - encrypted_code_execution_result
+                        required:
+                          - content
+                          - encrypted_stdout
+                          - return_code
+                          - stderr
+                          - type
+                  tool_use_id:
+                    type: string
+                required:
+                  - type
+                  - content
+                  - tool_use_id
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - bash_code_execution_tool_result
+                  content:
+                    oneOf:
+                      - type: object
+                        properties:
+                          error_code:
+                            type: string
+                            enum:
+                              - invalid_tool_input
+                              - unavailable
+                              - too_many_requests
+                              - execution_time_exceeded
+                              - output_file_too_large
+                          type:
+                            type: string
+                            enum:
+                              - bash_code_execution_tool_result_error
+                        required:
+                          - error_code
+                          - type
+                      - type: object
+                        properties:
+                          content:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                file_id:
+                                  type: string
+                                type:
+                                  type: string
+                                  enum:
+                                    - bash_code_execution_output
+                              required:
+                                - file_id
+                                - type
+                          return_code:
+                            type: number
+                          stderr:
+                            type: string
+                          stdout:
+                            type: string
+                          type:
+                            type: string
+                            enum:
+                              - bash_code_execution_result
+                        required:
+                          - content
+                          - return_code
+                          - stderr
+                          - stdout
+                          - type
+                  tool_use_id:
+                    type: string
+                required:
+                  - type
+                  - content
+                  - tool_use_id
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - text_editor_code_execution_tool_result
+                  content:
+                    oneOf:
+                      - type: object
+                        properties:
+                          error_code:
+                            type: string
+                            enum:
+                              - invalid_tool_input
+                              - unavailable
+                              - too_many_requests
+                              - execution_time_exceeded
+                              - file_not_found
+                          error_message:
+                            type: string
+                            nullable: true
+                          type:
+                            type: string
+                            enum:
+                              - text_editor_code_execution_tool_result_error
+                        required:
+                          - error_code
+                          - error_message
+                          - type
+                      - type: object
+                        properties:
+                          content:
+                            type: string
+                          file_type:
+                            type: string
+                            enum:
+                              - text
+                              - image
+                              - pdf
+                          num_lines:
+                            type: number
+                            nullable: true
+                          start_line:
+                            type: number
+                            nullable: true
+                          total_lines:
+                            type: number
+                            nullable: true
+                          type:
+                            type: string
+                            enum:
+                              - text_editor_code_execution_view_result
+                        required:
+                          - content
+                          - file_type
+                          - num_lines
+                          - start_line
+                          - total_lines
+                          - type
+                      - type: object
+                        properties:
+                          is_file_update:
+                            type: boolean
+                          type:
+                            type: string
+                            enum:
+                              - text_editor_code_execution_create_result
+                        required:
+                          - is_file_update
+                          - type
+                      - type: object
+                        properties:
+                          lines:
+                            type: array
+                            nullable: true
+                            items:
+                              type: string
+                          new_lines:
+                            type: number
+                            nullable: true
+                          new_start:
+                            type: number
+                            nullable: true
+                          old_lines:
+                            type: number
+                            nullable: true
+                          old_start:
+                            type: number
+                            nullable: true
+                          type:
+                            type: string
+                            enum:
+                              - text_editor_code_execution_str_replace_result
+                        required:
+                          - lines
+                          - new_lines
+                          - new_start
+                          - old_lines
+                          - old_start
+                          - type
+                  tool_use_id:
+                    type: string
+                required:
+                  - type
+                  - content
+                  - tool_use_id
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - tool_search_tool_result
+                  content:
+                    oneOf:
+                      - type: object
+                        properties:
+                          error_code:
+                            type: string
+                            enum:
+                              - invalid_tool_input
+                              - unavailable
+                              - too_many_requests
+                              - execution_time_exceeded
+                          error_message:
+                            type: string
+                            nullable: true
+                          type:
+                            type: string
+                            enum:
+                              - tool_search_tool_result_error
+                        required:
+                          - error_code
+                          - error_message
+                          - type
+                      - type: object
+                        properties:
+                          tool_references:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                tool_name:
+                                  type: string
+                                type:
+                                  type: string
+                                  enum:
+                                    - tool_reference
+                              required:
+                                - tool_name
+                                - type
+                          type:
+                            type: string
+                            enum:
+                              - tool_search_tool_search_result
+                        required:
+                          - tool_references
+                          - type
+                  tool_use_id:
+                    type: string
+                required:
+                  - type
+                  - content
+                  - tool_use_id
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - container_upload
+                  file_id:
+                    type: string
+                required:
+                  - type
+                  - file_id
         model:
           type: string
         stop_reason:
@@ -4393,7 +6116,6 @@ components:
             - tool_use
             - pause_turn
             - refusal
-            - model_context_window_exceeded
         stop_sequence:
           type: string
           nullable: true
@@ -4421,14 +6143,20 @@ components:
               required:
                 - ephemeral_5m_input_tokens
                 - ephemeral_1h_input_tokens
+            inference_geo:
+              type: string
+              nullable: true
             server_tool_use:
               type: object
               nullable: true
               properties:
                 web_search_requests:
                   type: number
+                web_fetch_requests:
+                  type: number
               required:
                 - web_search_requests
+                - web_fetch_requests
             service_tier:
               type: string
               nullable: true
@@ -4436,33 +6164,224 @@ components:
                 - standard
                 - priority
                 - batch
+            speed:
+              type: string
+              nullable: true
+              enum:
+                - fast
+                - standard
           required:
             - input_tokens
             - output_tokens
             - cache_creation_input_tokens
             - cache_read_input_tokens
             - cache_creation
+            - inference_geo
             - server_tool_use
             - service_tier
       required:
         - id
         - type
         - role
+        - container
         - content
         - model
         - stop_reason
         - stop_sequence
         - usage
-    AnthropicMessagesResponse:
+    MessagesResult:
       allOf:
-        - $ref: '#/components/schemas/BaseAnthropicMessagesResponse'
+        - $ref: '#/components/schemas/BaseMessagesResult'
         - type: object
-          properties: {}
+          properties:
+            usage:
+              type: object
+              properties:
+                input_tokens:
+                  type: number
+                output_tokens:
+                  type: number
+                cache_creation_input_tokens:
+                  type: number
+                  nullable: true
+                cache_read_input_tokens:
+                  type: number
+                  nullable: true
+                cache_creation:
+                  type: object
+                  nullable: true
+                  properties:
+                    ephemeral_5m_input_tokens:
+                      type: number
+                    ephemeral_1h_input_tokens:
+                      type: number
+                  required:
+                    - ephemeral_5m_input_tokens
+                    - ephemeral_1h_input_tokens
+                inference_geo:
+                  type: string
+                  nullable: true
+                server_tool_use:
+                  type: object
+                  nullable: true
+                  properties:
+                    web_search_requests:
+                      type: number
+                    web_fetch_requests:
+                      type: number
+                  required:
+                    - web_search_requests
+                    - web_fetch_requests
+                service_tier:
+                  type: string
+                  nullable: true
+                speed:
+                  type: string
+                  nullable: true
+                  enum:
+                    - fast
+                    - standard
+                cost:
+                  type: number
+                  nullable: true
+                is_byok:
+                  type: boolean
+                cost_details:
+                  type: object
+                  nullable: true
+                  properties:
+                    upstream_inference_cost:
+                      type: number
+                      nullable: true
+                    upstream_inference_prompt_cost:
+                      type: number
+                    upstream_inference_completions_cost:
+                      type: number
+                  required:
+                    - upstream_inference_prompt_cost
+                    - upstream_inference_completions_cost
+              required:
+                - input_tokens
+                - output_tokens
+                - cache_creation_input_tokens
+                - cache_read_input_tokens
+                - cache_creation
+                - inference_geo
+                - server_tool_use
+                - service_tier
+            provider:
+              type: string
+              enum:
+                - AnyScale
+                - Atoma
+                - Cent-ML
+                - CrofAI
+                - Enfer
+                - GoPomelo
+                - HuggingFace
+                - Hyperbolic 2
+                - InoCloud
+                - Kluster
+                - Lambda
+                - Lepton
+                - Lynn 2
+                - Lynn
+                - Mancer
+                - Meta
+                - Modal
+                - Nineteen
+                - OctoAI
+                - Recursal
+                - Reflection
+                - Replicate
+                - SambaNova 2
+                - SF Compute
+                - Targon
+                - Together 2
+                - Ubicloud
+                - 01.AI
+                - AkashML
+                - AI21
+                - AionLabs
+                - Alibaba
+                - Ambient
+                - Amazon Bedrock
+                - Amazon Nova
+                - Anthropic
+                - Arcee AI
+                - AtlasCloud
+                - Avian
+                - Azure
+                - BaseTen
+                - BytePlus
+                - Black Forest Labs
+                - Cerebras
+                - Chutes
+                - Cirrascale
+                - Clarifai
+                - Cloudflare
+                - Cohere
+                - Crusoe
+                - DeepInfra
+                - DeepSeek
+                - Featherless
+                - Fireworks
+                - Friendli
+                - GMICloud
+                - Google
+                - Google AI Studio
+                - Groq
+                - Hyperbolic
+                - Inception
+                - Inceptron
+                - InferenceNet
+                - Ionstream
+                - Infermatic
+                - Io Net
+                - Inflection
+                - Liquid
+                - Mara
+                - Mancer 2
+                - Minimax
+                - ModelRun
+                - Mistral
+                - Modular
+                - Moonshot AI
+                - Morph
+                - NCompass
+                - Nebius
+                - NextBit
+                - Novita
+                - Nvidia
+                - OpenAI
+                - OpenInference
+                - Parasail
+                - Perplexity
+                - Phala
+                - Reka
+                - Relace
+                - SambaNova
+                - Seed
+                - SiliconFlow
+                - Sourceful
+                - StepFun
+                - Stealth
+                - StreamLake
+                - Switchpoint
+                - Together
+                - Upstage
+                - Venice
+                - WandB
+                - Xiaomi
+                - xAI
+                - Z.AI
+                - FakeProvider
       description: Non-streaming response from the Anthropic Messages API with OpenRouter extensions
       example:
         id: msg_01XFDUDYJgAACzvnptvVoYEL
         type: message
         role: assistant
+        container: null
         content:
           - type: text
             text: Hello! I'm doing well, thank you for asking.
@@ -4476,360 +6395,1073 @@ components:
           cache_creation_input_tokens: null
           cache_read_input_tokens: null
           cache_creation: null
+          inference_geo: null
           server_tool_use: null
           service_tier: standard
-    AnthropicMessagesStreamEvent:
-      oneOf:
-        - type: object
+    MessagesStartEvent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - message_start
+        message:
+          type: object
           properties:
+            id:
+              type: string
             type:
               type: string
               enum:
-                - message_start
-            message:
+                - message
+            role:
+              type: string
+              enum:
+                - assistant
+            container:
               type: object
+              nullable: true
               properties:
                 id:
                   type: string
-                type:
+                expires_at:
                   type: string
-                  enum:
-                    - message
-                role:
-                  type: string
-                  enum:
-                    - assistant
-                content:
-                  type: array
-                  items:
-                    oneOf:
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            enum:
-                              - text
-                          text:
-                            type: string
-                          citations:
-                            type: array
-                            nullable: true
-                            items:
-                              oneOf:
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - char_location
-                                    cited_text:
-                                      type: string
-                                    document_index:
-                                      type: number
-                                    document_title:
-                                      type: string
-                                      nullable: true
-                                    start_char_index:
-                                      type: number
-                                    end_char_index:
-                                      type: number
-                                    file_id:
-                                      type: string
-                                      nullable: true
-                                  required:
-                                    - type
-                                    - cited_text
-                                    - document_index
-                                    - document_title
-                                    - start_char_index
-                                    - end_char_index
-                                    - file_id
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - page_location
-                                    cited_text:
-                                      type: string
-                                    document_index:
-                                      type: number
-                                    document_title:
-                                      type: string
-                                      nullable: true
-                                    start_page_number:
-                                      type: number
-                                    end_page_number:
-                                      type: number
-                                    file_id:
-                                      type: string
-                                      nullable: true
-                                  required:
-                                    - type
-                                    - cited_text
-                                    - document_index
-                                    - document_title
-                                    - start_page_number
-                                    - end_page_number
-                                    - file_id
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - content_block_location
-                                    cited_text:
-                                      type: string
-                                    document_index:
-                                      type: number
-                                    document_title:
-                                      type: string
-                                      nullable: true
-                                    start_block_index:
-                                      type: number
-                                    end_block_index:
-                                      type: number
-                                    file_id:
-                                      type: string
-                                      nullable: true
-                                  required:
-                                    - type
-                                    - cited_text
-                                    - document_index
-                                    - document_title
-                                    - start_block_index
-                                    - end_block_index
-                                    - file_id
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - web_search_result_location
-                                    cited_text:
-                                      type: string
-                                    encrypted_index:
-                                      type: string
-                                    title:
-                                      type: string
-                                      nullable: true
-                                    url:
-                                      type: string
-                                  required:
-                                    - type
-                                    - cited_text
-                                    - encrypted_index
-                                    - title
-                                    - url
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - search_result_location
-                                    cited_text:
-                                      type: string
-                                    search_result_index:
-                                      type: number
-                                    source:
-                                      type: string
-                                    title:
-                                      type: string
-                                      nullable: true
-                                    start_block_index:
-                                      type: number
-                                    end_block_index:
-                                      type: number
-                                  required:
-                                    - type
-                                    - cited_text
-                                    - search_result_index
-                                    - source
-                                    - title
-                                    - start_block_index
-                                    - end_block_index
-                        required:
-                          - type
+              required:
+                - id
+                - expires_at
+            content:
+              type: array
+              items:
+                oneOf:
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
                           - text
-                          - citations
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            enum:
-                              - tool_use
-                          id:
-                            type: string
-                          name:
-                            type: string
-                          input:
-                            nullable: true
-                        required:
-                          - type
-                          - id
-                          - name
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            enum:
-                              - thinking
-                          thinking:
-                            type: string
-                          signature:
-                            type: string
-                        required:
-                          - type
+                      text:
+                        type: string
+                      citations:
+                        type: array
+                        nullable: true
+                        items:
+                          oneOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - char_location
+                                cited_text:
+                                  type: string
+                                document_index:
+                                  type: number
+                                document_title:
+                                  type: string
+                                  nullable: true
+                                start_char_index:
+                                  type: number
+                                end_char_index:
+                                  type: number
+                                file_id:
+                                  type: string
+                                  nullable: true
+                              required:
+                                - type
+                                - cited_text
+                                - document_index
+                                - document_title
+                                - start_char_index
+                                - end_char_index
+                                - file_id
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - page_location
+                                cited_text:
+                                  type: string
+                                document_index:
+                                  type: number
+                                document_title:
+                                  type: string
+                                  nullable: true
+                                start_page_number:
+                                  type: number
+                                end_page_number:
+                                  type: number
+                                file_id:
+                                  type: string
+                                  nullable: true
+                              required:
+                                - type
+                                - cited_text
+                                - document_index
+                                - document_title
+                                - start_page_number
+                                - end_page_number
+                                - file_id
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - content_block_location
+                                cited_text:
+                                  type: string
+                                document_index:
+                                  type: number
+                                document_title:
+                                  type: string
+                                  nullable: true
+                                start_block_index:
+                                  type: number
+                                end_block_index:
+                                  type: number
+                                file_id:
+                                  type: string
+                                  nullable: true
+                              required:
+                                - type
+                                - cited_text
+                                - document_index
+                                - document_title
+                                - start_block_index
+                                - end_block_index
+                                - file_id
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - web_search_result_location
+                                cited_text:
+                                  type: string
+                                encrypted_index:
+                                  type: string
+                                title:
+                                  type: string
+                                  nullable: true
+                                url:
+                                  type: string
+                              required:
+                                - type
+                                - cited_text
+                                - encrypted_index
+                                - title
+                                - url
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - search_result_location
+                                cited_text:
+                                  type: string
+                                search_result_index:
+                                  type: number
+                                source:
+                                  type: string
+                                title:
+                                  type: string
+                                  nullable: true
+                                start_block_index:
+                                  type: number
+                                end_block_index:
+                                  type: number
+                              required:
+                                - type
+                                - cited_text
+                                - search_result_index
+                                - source
+                                - title
+                                - start_block_index
+                                - end_block_index
+                    required:
+                      - type
+                      - text
+                      - citations
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - tool_use
+                      id:
+                        type: string
+                      caller:
+                        oneOf:
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - direct
+                            required:
+                              - type
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_20250825
+                              tool_id:
+                                type: string
+                            required:
+                              - type
+                              - tool_id
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_20260120
+                              tool_id:
+                                type: string
+                            required:
+                              - type
+                              - tool_id
+                      name:
+                        type: string
+                      input:
+                        nullable: true
+                    required:
+                      - type
+                      - id
+                      - caller
+                      - name
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
                           - thinking
-                          - signature
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            enum:
-                              - redacted_thinking
-                          data:
-                            type: string
-                        required:
-                          - type
-                          - data
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            enum:
-                              - server_tool_use
-                          id:
-                            type: string
-                          name:
-                            type: string
-                            enum:
-                              - web_search
-                          input:
-                            nullable: true
-                        required:
-                          - type
-                          - id
-                          - name
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            enum:
-                              - web_search_tool_result
-                          tool_use_id:
-                            type: string
-                          content:
-                            anyOf:
-                              - type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - web_search_result
-                                    encrypted_content:
-                                      type: string
-                                    page_age:
-                                      type: string
-                                      nullable: true
-                                    title:
-                                      type: string
-                                    url:
-                                      type: string
-                                  required:
-                                    - type
-                                    - encrypted_content
-                                    - page_age
-                                    - title
-                                    - url
-                              - type: object
+                      thinking:
+                        type: string
+                      signature:
+                        type: string
+                    required:
+                      - type
+                      - thinking
+                      - signature
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - redacted_thinking
+                      data:
+                        type: string
+                    required:
+                      - type
+                      - data
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - server_tool_use
+                      id:
+                        type: string
+                      caller:
+                        oneOf:
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - direct
+                            required:
+                              - type
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_20250825
+                              tool_id:
+                                type: string
+                            required:
+                              - type
+                              - tool_id
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_20260120
+                              tool_id:
+                                type: string
+                            required:
+                              - type
+                              - tool_id
+                      name:
+                        type: string
+                        enum:
+                          - web_search
+                          - web_fetch
+                          - code_execution
+                          - bash_code_execution
+                          - text_editor_code_execution
+                          - tool_search_tool_regex
+                          - tool_search_tool_bm25
+                      input:
+                        nullable: true
+                    required:
+                      - type
+                      - id
+                      - caller
+                      - name
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - web_search_tool_result
+                      caller:
+                        oneOf:
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - direct
+                            required:
+                              - type
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_20250825
+                              tool_id:
+                                type: string
+                            required:
+                              - type
+                              - tool_id
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_20260120
+                              tool_id:
+                                type: string
+                            required:
+                              - type
+                              - tool_id
+                      tool_use_id:
+                        type: string
+                      content:
+                        anyOf:
+                          - type: array
+                            items:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - web_search_result
+                                encrypted_content:
+                                  type: string
+                                page_age:
+                                  type: string
+                                  nullable: true
+                                title:
+                                  type: string
+                                url:
+                                  type: string
+                              required:
+                                - type
+                                - encrypted_content
+                                - page_age
+                                - title
+                                - url
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - web_search_tool_result_error
+                              error_code:
+                                type: string
+                                enum:
+                                  - invalid_tool_input
+                                  - unavailable
+                                  - max_uses_exceeded
+                                  - too_many_requests
+                                  - query_too_long
+                                  - request_too_large
+                            required:
+                              - type
+                              - error_code
+                    required:
+                      - type
+                      - caller
+                      - tool_use_id
+                      - content
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - web_fetch_tool_result
+                      caller:
+                        oneOf:
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - direct
+                            required:
+                              - type
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_20250825
+                              tool_id:
+                                type: string
+                            required:
+                              - type
+                              - tool_id
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_20260120
+                              tool_id:
+                                type: string
+                            required:
+                              - type
+                              - tool_id
+                      content:
+                        oneOf:
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - web_fetch_tool_result_error
+                              error_code:
+                                type: string
+                                enum:
+                                  - invalid_tool_input
+                                  - url_too_long
+                                  - url_not_allowed
+                                  - url_not_accessible
+                                  - unsupported_content_type
+                                  - too_many_requests
+                                  - max_uses_exceeded
+                                  - unavailable
+                            required:
+                              - type
+                              - error_code
+                          - type: object
+                            properties:
+                              content:
+                                type: object
                                 properties:
+                                  citations:
+                                    type: object
+                                    nullable: true
+                                    properties:
+                                      enabled:
+                                        type: boolean
+                                    required:
+                                      - enabled
+                                  source:
+                                    anyOf:
+                                      - type: object
+                                        properties:
+                                          data:
+                                            type: string
+                                          media_type:
+                                            type: string
+                                            enum:
+                                              - application/pdf
+                                          type:
+                                            type: string
+                                            enum:
+                                              - base64
+                                        required:
+                                          - data
+                                          - media_type
+                                          - type
+                                      - type: object
+                                        properties:
+                                          data:
+                                            type: string
+                                          media_type:
+                                            type: string
+                                            enum:
+                                              - text/plain
+                                          type:
+                                            type: string
+                                            enum:
+                                              - text
+                                        required:
+                                          - data
+                                          - media_type
+                                          - type
+                                  title:
+                                    type: string
+                                    nullable: true
                                   type:
                                     type: string
                                     enum:
-                                      - web_search_tool_result_error
-                                  error_code:
-                                    type: string
-                                    enum:
-                                      - invalid_tool_input
-                                      - unavailable
-                                      - max_uses_exceeded
-                                      - too_many_requests
-                                      - query_too_long
+                                      - document
                                 required:
+                                  - citations
+                                  - source
+                                  - title
                                   - type
-                                  - error_code
-                        required:
-                          - type
-                          - tool_use_id
-                          - content
-                model:
-                  type: string
-                stop_reason:
+                              retrieved_at:
+                                type: string
+                                nullable: true
+                              type:
+                                type: string
+                                enum:
+                                  - web_fetch_result
+                              url:
+                                type: string
+                            required:
+                              - content
+                              - retrieved_at
+                              - type
+                              - url
+                      tool_use_id:
+                        type: string
+                    required:
+                      - type
+                      - caller
+                      - content
+                      - tool_use_id
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - code_execution_tool_result
+                      content:
+                        oneOf:
+                          - type: object
+                            properties:
+                              error_code:
+                                type: string
+                                enum:
+                                  - invalid_tool_input
+                                  - unavailable
+                                  - too_many_requests
+                                  - execution_time_exceeded
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_tool_result_error
+                            required:
+                              - error_code
+                              - type
+                          - type: object
+                            properties:
+                              content:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    file_id:
+                                      type: string
+                                    type:
+                                      type: string
+                                      enum:
+                                        - code_execution_output
+                                  required:
+                                    - file_id
+                                    - type
+                              return_code:
+                                type: number
+                              stderr:
+                                type: string
+                              stdout:
+                                type: string
+                              type:
+                                type: string
+                                enum:
+                                  - code_execution_result
+                            required:
+                              - content
+                              - return_code
+                              - stderr
+                              - stdout
+                              - type
+                          - type: object
+                            properties:
+                              content:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    file_id:
+                                      type: string
+                                    type:
+                                      type: string
+                                      enum:
+                                        - code_execution_output
+                                  required:
+                                    - file_id
+                                    - type
+                              encrypted_stdout:
+                                type: string
+                              return_code:
+                                type: number
+                              stderr:
+                                type: string
+                              type:
+                                type: string
+                                enum:
+                                  - encrypted_code_execution_result
+                            required:
+                              - content
+                              - encrypted_stdout
+                              - return_code
+                              - stderr
+                              - type
+                      tool_use_id:
+                        type: string
+                    required:
+                      - type
+                      - content
+                      - tool_use_id
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - bash_code_execution_tool_result
+                      content:
+                        oneOf:
+                          - type: object
+                            properties:
+                              error_code:
+                                type: string
+                                enum:
+                                  - invalid_tool_input
+                                  - unavailable
+                                  - too_many_requests
+                                  - execution_time_exceeded
+                                  - output_file_too_large
+                              type:
+                                type: string
+                                enum:
+                                  - bash_code_execution_tool_result_error
+                            required:
+                              - error_code
+                              - type
+                          - type: object
+                            properties:
+                              content:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    file_id:
+                                      type: string
+                                    type:
+                                      type: string
+                                      enum:
+                                        - bash_code_execution_output
+                                  required:
+                                    - file_id
+                                    - type
+                              return_code:
+                                type: number
+                              stderr:
+                                type: string
+                              stdout:
+                                type: string
+                              type:
+                                type: string
+                                enum:
+                                  - bash_code_execution_result
+                            required:
+                              - content
+                              - return_code
+                              - stderr
+                              - stdout
+                              - type
+                      tool_use_id:
+                        type: string
+                    required:
+                      - type
+                      - content
+                      - tool_use_id
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - text_editor_code_execution_tool_result
+                      content:
+                        oneOf:
+                          - type: object
+                            properties:
+                              error_code:
+                                type: string
+                                enum:
+                                  - invalid_tool_input
+                                  - unavailable
+                                  - too_many_requests
+                                  - execution_time_exceeded
+                                  - file_not_found
+                              error_message:
+                                type: string
+                                nullable: true
+                              type:
+                                type: string
+                                enum:
+                                  - text_editor_code_execution_tool_result_error
+                            required:
+                              - error_code
+                              - error_message
+                              - type
+                          - type: object
+                            properties:
+                              content:
+                                type: string
+                              file_type:
+                                type: string
+                                enum:
+                                  - text
+                                  - image
+                                  - pdf
+                              num_lines:
+                                type: number
+                                nullable: true
+                              start_line:
+                                type: number
+                                nullable: true
+                              total_lines:
+                                type: number
+                                nullable: true
+                              type:
+                                type: string
+                                enum:
+                                  - text_editor_code_execution_view_result
+                            required:
+                              - content
+                              - file_type
+                              - num_lines
+                              - start_line
+                              - total_lines
+                              - type
+                          - type: object
+                            properties:
+                              is_file_update:
+                                type: boolean
+                              type:
+                                type: string
+                                enum:
+                                  - text_editor_code_execution_create_result
+                            required:
+                              - is_file_update
+                              - type
+                          - type: object
+                            properties:
+                              lines:
+                                type: array
+                                nullable: true
+                                items:
+                                  type: string
+                              new_lines:
+                                type: number
+                                nullable: true
+                              new_start:
+                                type: number
+                                nullable: true
+                              old_lines:
+                                type: number
+                                nullable: true
+                              old_start:
+                                type: number
+                                nullable: true
+                              type:
+                                type: string
+                                enum:
+                                  - text_editor_code_execution_str_replace_result
+                            required:
+                              - lines
+                              - new_lines
+                              - new_start
+                              - old_lines
+                              - old_start
+                              - type
+                      tool_use_id:
+                        type: string
+                    required:
+                      - type
+                      - content
+                      - tool_use_id
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - tool_search_tool_result
+                      content:
+                        oneOf:
+                          - type: object
+                            properties:
+                              error_code:
+                                type: string
+                                enum:
+                                  - invalid_tool_input
+                                  - unavailable
+                                  - too_many_requests
+                                  - execution_time_exceeded
+                              error_message:
+                                type: string
+                                nullable: true
+                              type:
+                                type: string
+                                enum:
+                                  - tool_search_tool_result_error
+                            required:
+                              - error_code
+                              - error_message
+                              - type
+                          - type: object
+                            properties:
+                              tool_references:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    tool_name:
+                                      type: string
+                                    type:
+                                      type: string
+                                      enum:
+                                        - tool_reference
+                                  required:
+                                    - tool_name
+                                    - type
+                              type:
+                                type: string
+                                enum:
+                                  - tool_search_tool_search_result
+                            required:
+                              - tool_references
+                              - type
+                      tool_use_id:
+                        type: string
+                    required:
+                      - type
+                      - content
+                      - tool_use_id
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - container_upload
+                      file_id:
+                        type: string
+                    required:
+                      - type
+                      - file_id
+            model:
+              type: string
+            stop_reason:
+              nullable: true
+            stop_sequence:
+              nullable: true
+            usage:
+              type: object
+              properties:
+                input_tokens:
+                  type: number
+                output_tokens:
+                  type: number
+                cache_creation_input_tokens:
+                  type: number
                   nullable: true
-                stop_sequence:
+                cache_read_input_tokens:
+                  type: number
                   nullable: true
-                usage:
+                cache_creation:
                   type: object
+                  nullable: true
                   properties:
-                    input_tokens:
+                    ephemeral_5m_input_tokens:
                       type: number
-                    output_tokens:
+                    ephemeral_1h_input_tokens:
                       type: number
-                    cache_creation_input_tokens:
-                      type: number
-                      nullable: true
-                    cache_read_input_tokens:
-                      type: number
-                      nullable: true
-                    cache_creation:
-                      type: object
-                      nullable: true
-                      properties:
-                        ephemeral_5m_input_tokens:
-                          type: number
-                        ephemeral_1h_input_tokens:
-                          type: number
-                      required:
-                        - ephemeral_5m_input_tokens
-                        - ephemeral_1h_input_tokens
-                    server_tool_use:
-                      type: object
-                      nullable: true
-                      properties:
-                        web_search_requests:
-                          type: number
-                      required:
-                        - web_search_requests
-                    service_tier:
-                      type: string
-                      nullable: true
-                      enum:
-                        - standard
-                        - priority
-                        - batch
                   required:
-                    - input_tokens
-                    - output_tokens
-                    - cache_creation_input_tokens
-                    - cache_read_input_tokens
-                    - cache_creation
-                    - server_tool_use
-                    - service_tier
+                    - ephemeral_5m_input_tokens
+                    - ephemeral_1h_input_tokens
+                inference_geo:
+                  type: string
+                  nullable: true
+                server_tool_use:
+                  type: object
+                  nullable: true
+                  properties:
+                    web_search_requests:
+                      type: number
+                    web_fetch_requests:
+                      type: number
+                  required:
+                    - web_search_requests
+                    - web_fetch_requests
+                service_tier:
+                  type: string
+                  nullable: true
+                  enum:
+                    - standard
+                    - priority
+                    - batch
+                speed:
+                  type: string
+                  nullable: true
+                  enum:
+                    - fast
+                    - standard
               required:
-                - id
-                - type
-                - role
-                - content
-                - model
-                - stop_reason
-                - stop_sequence
-                - usage
+                - input_tokens
+                - output_tokens
+                - cache_creation_input_tokens
+                - cache_read_input_tokens
+                - cache_creation
+                - inference_geo
+                - server_tool_use
+                - service_tier
+            provider:
+              type: string
+              enum:
+                - AnyScale
+                - Atoma
+                - Cent-ML
+                - CrofAI
+                - Enfer
+                - GoPomelo
+                - HuggingFace
+                - Hyperbolic 2
+                - InoCloud
+                - Kluster
+                - Lambda
+                - Lepton
+                - Lynn 2
+                - Lynn
+                - Mancer
+                - Meta
+                - Modal
+                - Nineteen
+                - OctoAI
+                - Recursal
+                - Reflection
+                - Replicate
+                - SambaNova 2
+                - SF Compute
+                - Targon
+                - Together 2
+                - Ubicloud
+                - 01.AI
+                - AkashML
+                - AI21
+                - AionLabs
+                - Alibaba
+                - Ambient
+                - Amazon Bedrock
+                - Amazon Nova
+                - Anthropic
+                - Arcee AI
+                - AtlasCloud
+                - Avian
+                - Azure
+                - BaseTen
+                - BytePlus
+                - Black Forest Labs
+                - Cerebras
+                - Chutes
+                - Cirrascale
+                - Clarifai
+                - Cloudflare
+                - Cohere
+                - Crusoe
+                - DeepInfra
+                - DeepSeek
+                - Featherless
+                - Fireworks
+                - Friendli
+                - GMICloud
+                - Google
+                - Google AI Studio
+                - Groq
+                - Hyperbolic
+                - Inception
+                - Inceptron
+                - InferenceNet
+                - Ionstream
+                - Infermatic
+                - Io Net
+                - Inflection
+                - Liquid
+                - Mara
+                - Mancer 2
+                - Minimax
+                - ModelRun
+                - Mistral
+                - Modular
+                - Moonshot AI
+                - Morph
+                - NCompass
+                - Nebius
+                - NextBit
+                - Novita
+                - Nvidia
+                - OpenAI
+                - OpenInference
+                - Parasail
+                - Perplexity
+                - Phala
+                - Reka
+                - Relace
+                - SambaNova
+                - Seed
+                - SiliconFlow
+                - Sourceful
+                - StepFun
+                - Stealth
+                - StreamLake
+                - Switchpoint
+                - Together
+                - Upstage
+                - Venice
+                - WandB
+                - Xiaomi
+                - xAI
+                - Z.AI
+                - FakeProvider
           required:
+            - id
             - type
-            - message
+            - role
+            - container
+            - content
+            - model
+            - stop_reason
+            - stop_sequence
+            - usage
+      required:
+        - type
+        - message
+      description: Event sent at the start of a streaming message
+    MessagesStreamEvents:
+      oneOf:
+        - $ref: '#/components/schemas/MessagesStartEvent'
         - type: object
           properties:
             type:
@@ -4839,6 +7471,17 @@ components:
             delta:
               type: object
               properties:
+                container:
+                  type: object
+                  nullable: true
+                  properties:
+                    id:
+                      type: string
+                    expires_at:
+                      type: string
+                  required:
+                    - id
+                    - expires_at
                 stop_reason:
                   type: string
                   nullable: true
@@ -4849,11 +7492,11 @@ components:
                     - tool_use
                     - pause_turn
                     - refusal
-                    - model_context_window_exceeded
                 stop_sequence:
                   type: string
                   nullable: true
               required:
+                - container
                 - stop_reason
                 - stop_sequence
             usage:
@@ -4876,8 +7519,11 @@ components:
                   properties:
                     web_search_requests:
                       type: number
+                    web_fetch_requests:
+                      type: number
                   required:
                     - web_search_requests
+                    - web_fetch_requests
               required:
                 - input_tokens
                 - output_tokens
@@ -5063,6 +7709,38 @@ components:
                         - tool_use
                     id:
                       type: string
+                    caller:
+                      oneOf:
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - direct
+                          required:
+                            - type
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_20250825
+                            tool_id:
+                              type: string
+                          required:
+                            - type
+                            - tool_id
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_20260120
+                            tool_id:
+                              type: string
+                          required:
+                            - type
+                            - tool_id
                     name:
                       type: string
                     input:
@@ -5070,6 +7748,7 @@ components:
                   required:
                     - type
                     - id
+                    - caller
                     - name
                 - type: object
                   properties:
@@ -5104,15 +7783,54 @@ components:
                         - server_tool_use
                     id:
                       type: string
+                    caller:
+                      oneOf:
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - direct
+                          required:
+                            - type
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_20250825
+                            tool_id:
+                              type: string
+                          required:
+                            - type
+                            - tool_id
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_20260120
+                            tool_id:
+                              type: string
+                          required:
+                            - type
+                            - tool_id
                     name:
                       type: string
                       enum:
                         - web_search
+                        - web_fetch
+                        - code_execution
+                        - bash_code_execution
+                        - text_editor_code_execution
+                        - tool_search_tool_regex
+                        - tool_search_tool_bm25
                     input:
                       nullable: true
                   required:
                     - type
                     - id
+                    - caller
                     - name
                 - type: object
                   properties:
@@ -5120,6 +7838,38 @@ components:
                       type: string
                       enum:
                         - web_search_tool_result
+                    caller:
+                      oneOf:
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - direct
+                          required:
+                            - type
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_20250825
+                            tool_id:
+                              type: string
+                          required:
+                            - type
+                            - tool_id
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_20260120
+                            tool_id:
+                              type: string
+                          required:
+                            - type
+                            - tool_id
                     tool_use_id:
                       type: string
                     content:
@@ -5161,13 +7911,486 @@ components:
                                 - max_uses_exceeded
                                 - too_many_requests
                                 - query_too_long
+                                - request_too_large
                           required:
                             - type
                             - error_code
                   required:
                     - type
+                    - caller
                     - tool_use_id
                     - content
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - web_fetch_tool_result
+                    caller:
+                      oneOf:
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - direct
+                          required:
+                            - type
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_20250825
+                            tool_id:
+                              type: string
+                          required:
+                            - type
+                            - tool_id
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_20260120
+                            tool_id:
+                              type: string
+                          required:
+                            - type
+                            - tool_id
+                    content:
+                      oneOf:
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - web_fetch_tool_result_error
+                            error_code:
+                              type: string
+                              enum:
+                                - invalid_tool_input
+                                - url_too_long
+                                - url_not_allowed
+                                - url_not_accessible
+                                - unsupported_content_type
+                                - too_many_requests
+                                - max_uses_exceeded
+                                - unavailable
+                          required:
+                            - type
+                            - error_code
+                        - type: object
+                          properties:
+                            content:
+                              type: object
+                              properties:
+                                citations:
+                                  type: object
+                                  nullable: true
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  required:
+                                    - enabled
+                                source:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        data:
+                                          type: string
+                                        media_type:
+                                          type: string
+                                          enum:
+                                            - application/pdf
+                                        type:
+                                          type: string
+                                          enum:
+                                            - base64
+                                      required:
+                                        - data
+                                        - media_type
+                                        - type
+                                    - type: object
+                                      properties:
+                                        data:
+                                          type: string
+                                        media_type:
+                                          type: string
+                                          enum:
+                                            - text/plain
+                                        type:
+                                          type: string
+                                          enum:
+                                            - text
+                                      required:
+                                        - data
+                                        - media_type
+                                        - type
+                                title:
+                                  type: string
+                                  nullable: true
+                                type:
+                                  type: string
+                                  enum:
+                                    - document
+                              required:
+                                - citations
+                                - source
+                                - title
+                                - type
+                            retrieved_at:
+                              type: string
+                              nullable: true
+                            type:
+                              type: string
+                              enum:
+                                - web_fetch_result
+                            url:
+                              type: string
+                          required:
+                            - content
+                            - retrieved_at
+                            - type
+                            - url
+                    tool_use_id:
+                      type: string
+                  required:
+                    - type
+                    - caller
+                    - content
+                    - tool_use_id
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - code_execution_tool_result
+                    content:
+                      oneOf:
+                        - type: object
+                          properties:
+                            error_code:
+                              type: string
+                              enum:
+                                - invalid_tool_input
+                                - unavailable
+                                - too_many_requests
+                                - execution_time_exceeded
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_tool_result_error
+                          required:
+                            - error_code
+                            - type
+                        - type: object
+                          properties:
+                            content:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  file_id:
+                                    type: string
+                                  type:
+                                    type: string
+                                    enum:
+                                      - code_execution_output
+                                required:
+                                  - file_id
+                                  - type
+                            return_code:
+                              type: number
+                            stderr:
+                              type: string
+                            stdout:
+                              type: string
+                            type:
+                              type: string
+                              enum:
+                                - code_execution_result
+                          required:
+                            - content
+                            - return_code
+                            - stderr
+                            - stdout
+                            - type
+                        - type: object
+                          properties:
+                            content:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  file_id:
+                                    type: string
+                                  type:
+                                    type: string
+                                    enum:
+                                      - code_execution_output
+                                required:
+                                  - file_id
+                                  - type
+                            encrypted_stdout:
+                              type: string
+                            return_code:
+                              type: number
+                            stderr:
+                              type: string
+                            type:
+                              type: string
+                              enum:
+                                - encrypted_code_execution_result
+                          required:
+                            - content
+                            - encrypted_stdout
+                            - return_code
+                            - stderr
+                            - type
+                    tool_use_id:
+                      type: string
+                  required:
+                    - type
+                    - content
+                    - tool_use_id
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - bash_code_execution_tool_result
+                    content:
+                      oneOf:
+                        - type: object
+                          properties:
+                            error_code:
+                              type: string
+                              enum:
+                                - invalid_tool_input
+                                - unavailable
+                                - too_many_requests
+                                - execution_time_exceeded
+                                - output_file_too_large
+                            type:
+                              type: string
+                              enum:
+                                - bash_code_execution_tool_result_error
+                          required:
+                            - error_code
+                            - type
+                        - type: object
+                          properties:
+                            content:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  file_id:
+                                    type: string
+                                  type:
+                                    type: string
+                                    enum:
+                                      - bash_code_execution_output
+                                required:
+                                  - file_id
+                                  - type
+                            return_code:
+                              type: number
+                            stderr:
+                              type: string
+                            stdout:
+                              type: string
+                            type:
+                              type: string
+                              enum:
+                                - bash_code_execution_result
+                          required:
+                            - content
+                            - return_code
+                            - stderr
+                            - stdout
+                            - type
+                    tool_use_id:
+                      type: string
+                  required:
+                    - type
+                    - content
+                    - tool_use_id
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - text_editor_code_execution_tool_result
+                    content:
+                      oneOf:
+                        - type: object
+                          properties:
+                            error_code:
+                              type: string
+                              enum:
+                                - invalid_tool_input
+                                - unavailable
+                                - too_many_requests
+                                - execution_time_exceeded
+                                - file_not_found
+                            error_message:
+                              type: string
+                              nullable: true
+                            type:
+                              type: string
+                              enum:
+                                - text_editor_code_execution_tool_result_error
+                          required:
+                            - error_code
+                            - error_message
+                            - type
+                        - type: object
+                          properties:
+                            content:
+                              type: string
+                            file_type:
+                              type: string
+                              enum:
+                                - text
+                                - image
+                                - pdf
+                            num_lines:
+                              type: number
+                              nullable: true
+                            start_line:
+                              type: number
+                              nullable: true
+                            total_lines:
+                              type: number
+                              nullable: true
+                            type:
+                              type: string
+                              enum:
+                                - text_editor_code_execution_view_result
+                          required:
+                            - content
+                            - file_type
+                            - num_lines
+                            - start_line
+                            - total_lines
+                            - type
+                        - type: object
+                          properties:
+                            is_file_update:
+                              type: boolean
+                            type:
+                              type: string
+                              enum:
+                                - text_editor_code_execution_create_result
+                          required:
+                            - is_file_update
+                            - type
+                        - type: object
+                          properties:
+                            lines:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                            new_lines:
+                              type: number
+                              nullable: true
+                            new_start:
+                              type: number
+                              nullable: true
+                            old_lines:
+                              type: number
+                              nullable: true
+                            old_start:
+                              type: number
+                              nullable: true
+                            type:
+                              type: string
+                              enum:
+                                - text_editor_code_execution_str_replace_result
+                          required:
+                            - lines
+                            - new_lines
+                            - new_start
+                            - old_lines
+                            - old_start
+                            - type
+                    tool_use_id:
+                      type: string
+                  required:
+                    - type
+                    - content
+                    - tool_use_id
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - tool_search_tool_result
+                    content:
+                      oneOf:
+                        - type: object
+                          properties:
+                            error_code:
+                              type: string
+                              enum:
+                                - invalid_tool_input
+                                - unavailable
+                                - too_many_requests
+                                - execution_time_exceeded
+                            error_message:
+                              type: string
+                              nullable: true
+                            type:
+                              type: string
+                              enum:
+                                - tool_search_tool_result_error
+                          required:
+                            - error_code
+                            - error_message
+                            - type
+                        - type: object
+                          properties:
+                            tool_references:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  tool_name:
+                                    type: string
+                                  type:
+                                    type: string
+                                    enum:
+                                      - tool_reference
+                                required:
+                                  - tool_name
+                                  - type
+                            type:
+                              type: string
+                              enum:
+                                - tool_search_tool_search_result
+                          required:
+                            - tool_references
+                            - type
+                    tool_use_id:
+                      type: string
+                  required:
+                    - type
+                    - content
+                    - tool_use_id
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - container_upload
+                    file_id:
+                      type: string
+                  required:
+                    - type
+                    - file_id
           required:
             - type
             - index
@@ -5412,7 +8635,7 @@ components:
             - type
             - error
       description: Union of all possible streaming events
-    OpenRouterAnthropicMessageParam:
+    MessagesMessageParam:
       type: object
       properties:
         role:
@@ -6180,6 +9403,504 @@ components:
                                   required:
                                     - type
                                     - source
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - tool_reference
+                                    tool_name:
+                                      type: string
+                                  required:
+                                    - type
+                                    - tool_name
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - search_result
+                                    source:
+                                      type: string
+                                    title:
+                                      type: string
+                                    content:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - text
+                                          text:
+                                            type: string
+                                          citations:
+                                            type: array
+                                            nullable: true
+                                            items:
+                                              oneOf:
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - char_location
+                                                    cited_text:
+                                                      type: string
+                                                    document_index:
+                                                      type: number
+                                                    document_title:
+                                                      type: string
+                                                      nullable: true
+                                                    start_char_index:
+                                                      type: number
+                                                    end_char_index:
+                                                      type: number
+                                                  required:
+                                                    - type
+                                                    - cited_text
+                                                    - document_index
+                                                    - document_title
+                                                    - start_char_index
+                                                    - end_char_index
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - page_location
+                                                    cited_text:
+                                                      type: string
+                                                    document_index:
+                                                      type: number
+                                                    document_title:
+                                                      type: string
+                                                      nullable: true
+                                                    start_page_number:
+                                                      type: number
+                                                    end_page_number:
+                                                      type: number
+                                                  required:
+                                                    - type
+                                                    - cited_text
+                                                    - document_index
+                                                    - document_title
+                                                    - start_page_number
+                                                    - end_page_number
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - content_block_location
+                                                    cited_text:
+                                                      type: string
+                                                    document_index:
+                                                      type: number
+                                                    document_title:
+                                                      type: string
+                                                      nullable: true
+                                                    start_block_index:
+                                                      type: number
+                                                    end_block_index:
+                                                      type: number
+                                                  required:
+                                                    - type
+                                                    - cited_text
+                                                    - document_index
+                                                    - document_title
+                                                    - start_block_index
+                                                    - end_block_index
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - web_search_result_location
+                                                    cited_text:
+                                                      type: string
+                                                    encrypted_index:
+                                                      type: string
+                                                    title:
+                                                      type: string
+                                                      nullable: true
+                                                    url:
+                                                      type: string
+                                                  required:
+                                                    - type
+                                                    - cited_text
+                                                    - encrypted_index
+                                                    - title
+                                                    - url
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - search_result_location
+                                                    cited_text:
+                                                      type: string
+                                                    search_result_index:
+                                                      type: number
+                                                    source:
+                                                      type: string
+                                                    title:
+                                                      type: string
+                                                      nullable: true
+                                                    start_block_index:
+                                                      type: number
+                                                    end_block_index:
+                                                      type: number
+                                                  required:
+                                                    - type
+                                                    - cited_text
+                                                    - search_result_index
+                                                    - source
+                                                    - title
+                                                    - start_block_index
+                                                    - end_block_index
+                                          cache_control:
+                                            type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - ephemeral
+                                              ttl:
+                                                type: string
+                                                enum:
+                                                  - 5m
+                                                  - 1h
+                                            required:
+                                              - type
+                                        required:
+                                          - type
+                                          - text
+                                    citations:
+                                      type: object
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                    cache_control:
+                                      type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          enum:
+                                            - ephemeral
+                                        ttl:
+                                          type: string
+                                          enum:
+                                            - 5m
+                                            - 1h
+                                      required:
+                                        - type
+                                  required:
+                                    - type
+                                    - source
+                                    - title
+                                    - content
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - document
+                                    source:
+                                      oneOf:
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - base64
+                                            media_type:
+                                              type: string
+                                              enum:
+                                                - application/pdf
+                                            data:
+                                              type: string
+                                          required:
+                                            - type
+                                            - media_type
+                                            - data
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - text
+                                            media_type:
+                                              type: string
+                                              enum:
+                                                - text/plain
+                                            data:
+                                              type: string
+                                          required:
+                                            - type
+                                            - media_type
+                                            - data
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - content
+                                            content:
+                                              anyOf:
+                                                - type: string
+                                                - type: array
+                                                  items:
+                                                    oneOf:
+                                                      - type: object
+                                                        properties:
+                                                          type:
+                                                            type: string
+                                                            enum:
+                                                              - text
+                                                          text:
+                                                            type: string
+                                                          citations:
+                                                            type: array
+                                                            nullable: true
+                                                            items:
+                                                              oneOf:
+                                                                - type: object
+                                                                  properties:
+                                                                    type:
+                                                                      type: string
+                                                                      enum:
+                                                                        - char_location
+                                                                    cited_text:
+                                                                      type: string
+                                                                    document_index:
+                                                                      type: number
+                                                                    document_title:
+                                                                      type: string
+                                                                      nullable: true
+                                                                    start_char_index:
+                                                                      type: number
+                                                                    end_char_index:
+                                                                      type: number
+                                                                  required:
+                                                                    - type
+                                                                    - cited_text
+                                                                    - document_index
+                                                                    - document_title
+                                                                    - start_char_index
+                                                                    - end_char_index
+                                                                - type: object
+                                                                  properties:
+                                                                    type:
+                                                                      type: string
+                                                                      enum:
+                                                                        - page_location
+                                                                    cited_text:
+                                                                      type: string
+                                                                    document_index:
+                                                                      type: number
+                                                                    document_title:
+                                                                      type: string
+                                                                      nullable: true
+                                                                    start_page_number:
+                                                                      type: number
+                                                                    end_page_number:
+                                                                      type: number
+                                                                  required:
+                                                                    - type
+                                                                    - cited_text
+                                                                    - document_index
+                                                                    - document_title
+                                                                    - start_page_number
+                                                                    - end_page_number
+                                                                - type: object
+                                                                  properties:
+                                                                    type:
+                                                                      type: string
+                                                                      enum:
+                                                                        - content_block_location
+                                                                    cited_text:
+                                                                      type: string
+                                                                    document_index:
+                                                                      type: number
+                                                                    document_title:
+                                                                      type: string
+                                                                      nullable: true
+                                                                    start_block_index:
+                                                                      type: number
+                                                                    end_block_index:
+                                                                      type: number
+                                                                  required:
+                                                                    - type
+                                                                    - cited_text
+                                                                    - document_index
+                                                                    - document_title
+                                                                    - start_block_index
+                                                                    - end_block_index
+                                                                - type: object
+                                                                  properties:
+                                                                    type:
+                                                                      type: string
+                                                                      enum:
+                                                                        - web_search_result_location
+                                                                    cited_text:
+                                                                      type: string
+                                                                    encrypted_index:
+                                                                      type: string
+                                                                    title:
+                                                                      type: string
+                                                                      nullable: true
+                                                                    url:
+                                                                      type: string
+                                                                  required:
+                                                                    - type
+                                                                    - cited_text
+                                                                    - encrypted_index
+                                                                    - title
+                                                                    - url
+                                                                - type: object
+                                                                  properties:
+                                                                    type:
+                                                                      type: string
+                                                                      enum:
+                                                                        - search_result_location
+                                                                    cited_text:
+                                                                      type: string
+                                                                    search_result_index:
+                                                                      type: number
+                                                                    source:
+                                                                      type: string
+                                                                    title:
+                                                                      type: string
+                                                                      nullable: true
+                                                                    start_block_index:
+                                                                      type: number
+                                                                    end_block_index:
+                                                                      type: number
+                                                                  required:
+                                                                    - type
+                                                                    - cited_text
+                                                                    - search_result_index
+                                                                    - source
+                                                                    - title
+                                                                    - start_block_index
+                                                                    - end_block_index
+                                                          cache_control:
+                                                            type: object
+                                                            properties:
+                                                              type:
+                                                                type: string
+                                                                enum:
+                                                                  - ephemeral
+                                                              ttl:
+                                                                type: string
+                                                                enum:
+                                                                  - 5m
+                                                                  - 1h
+                                                            required:
+                                                              - type
+                                                        required:
+                                                          - type
+                                                          - text
+                                                      - type: object
+                                                        properties:
+                                                          type:
+                                                            type: string
+                                                            enum:
+                                                              - image
+                                                          source:
+                                                            oneOf:
+                                                              - type: object
+                                                                properties:
+                                                                  type:
+                                                                    type: string
+                                                                    enum:
+                                                                      - base64
+                                                                  media_type:
+                                                                    type: string
+                                                                    enum:
+                                                                      - image/jpeg
+                                                                      - image/png
+                                                                      - image/gif
+                                                                      - image/webp
+                                                                  data:
+                                                                    type: string
+                                                                required:
+                                                                  - type
+                                                                  - media_type
+                                                                  - data
+                                                              - type: object
+                                                                properties:
+                                                                  type:
+                                                                    type: string
+                                                                    enum:
+                                                                      - url
+                                                                  url:
+                                                                    type: string
+                                                                required:
+                                                                  - type
+                                                                  - url
+                                                          cache_control:
+                                                            type: object
+                                                            properties:
+                                                              type:
+                                                                type: string
+                                                                enum:
+                                                                  - ephemeral
+                                                              ttl:
+                                                                type: string
+                                                                enum:
+                                                                  - 5m
+                                                                  - 1h
+                                                            required:
+                                                              - type
+                                                        required:
+                                                          - type
+                                                          - source
+                                          required:
+                                            - type
+                                            - content
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - url
+                                            url:
+                                              type: string
+                                          required:
+                                            - type
+                                            - url
+                                    citations:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                    context:
+                                      type: string
+                                      nullable: true
+                                    title:
+                                      type: string
+                                      nullable: true
+                                    cache_control:
+                                      type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          enum:
+                                            - ephemeral
+                                        ttl:
+                                          type: string
+                                          enum:
+                                            - 5m
+                                            - 1h
+                                      required:
+                                        - type
+                                  required:
+                                    - type
+                                    - source
                       is_error:
                         type: boolean
                       cache_control:
@@ -6236,6 +9957,12 @@ components:
                         type: string
                         enum:
                           - web_search
+                          - web_fetch
+                          - code_execution
+                          - bash_code_execution
+                          - text_editor_code_execution
+                          - tool_search_tool_regex
+                          - tool_search_tool_bm25
                       input:
                         nullable: true
                       cache_control:
@@ -6514,17 +10241,137 @@ components:
         - role
         - content
       description: Anthropic message with OpenRouter extensions
-    AnthropicMessagesRequest:
+    MessagesWebSearchServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - openrouter:web_search
+        parameters:
+          type: object
+          properties:
+            engine:
+              type: string
+              enum:
+                - auto
+                - native
+                - exa
+                - firecrawl
+                - parallel
+              description: >-
+                Which search engine to use. "auto" (default) uses native if the provider supports it, otherwise Exa.
+                "native" forces the provider's built-in search. "exa" forces the Exa search API. "firecrawl" uses
+                Firecrawl (requires BYOK). "parallel" uses the Parallel search API.
+              example: auto
+            max_results:
+              type: number
+              minimum: 1
+              maximum: 25
+              description: >-
+                Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl,
+                and Parallel engines; ignored with native provider search.
+              example: 5
+            max_total_results:
+              type: number
+              minimum: 1
+              description: >-
+                Maximum total number of search results across all search calls in a single request. Once this limit is
+                reached, the tool will stop returning new results. Useful for controlling cost and context size in
+                agentic loops.
+              example: 20
+            search_context_size:
+              type: string
+              enum:
+                - low
+                - medium
+                - high
+              description: >-
+                How much context to retrieve per result. Defaults to medium (15000 chars). Only applies when using the
+                Exa engine; ignored with native provider search.
+            user_location:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - approximate
+                city:
+                  type: string
+                region:
+                  type: string
+                country:
+                  type: string
+                timezone:
+                  type: string
+              description: Approximate user location for location-biased results.
+            allowed_domains:
+              type: array
+              items:
+                type: string
+              description: >-
+                Limit search results to these domains. Supported by Exa, Parallel, and most native providers (Anthropic,
+                OpenAI, xAI). Not supported with Firecrawl or Perplexity.
+            excluded_domains:
+              type: array
+              items:
+                type: string
+              description: >-
+                Exclude search results from these domains. Supported by Exa, Parallel, Anthropic, and xAI. Not supported
+                with Firecrawl, OpenAI (silently ignored), or Perplexity.
+      required:
+        - type
+      description: 'OpenRouter built-in server tool: searches the web for current information'
+      example:
+        type: openrouter:web_search
+        parameters:
+          max_results: 5
+    MessagesOutputConfig:
+      type: object
+      properties:
+        effort:
+          type: string
+          nullable: true
+          enum:
+            - low
+            - medium
+            - high
+            - max
+          description: >-
+            How much effort the model should put into its response. Higher effort levels may result in more thorough
+            analysis but take longer. Valid values are `low`, `medium`, `high`, or `max`.
+          example: medium
+        format:
+          type: object
+          nullable: true
+          properties:
+            type:
+              type: string
+              enum:
+                - json_schema
+            schema:
+              type: object
+              additionalProperties:
+                nullable: true
+          required:
+            - type
+            - schema
+          description: >-
+            A schema to specify Claude's output format in responses. See [structured
+            outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs).
+      description: Configuration for controlling output behavior. Supports the effort parameter and structured output format.
+    MessagesRequest:
       type: object
       properties:
         model:
           type: string
         max_tokens:
-          type: number
+          type: integer
         messages:
           type: array
+          nullable: true
           items:
-            $ref: '#/components/schemas/OpenRouterAnthropicMessageParam'
+            $ref: '#/components/schemas/MessagesMessageParam'
         system:
           anyOf:
             - type: string
@@ -6690,8 +10537,6 @@ components:
           type: array
           items:
             type: string
-        stream:
-          type: boolean
         temperature:
           type: number
         top_p:
@@ -6701,7 +10546,7 @@ components:
         tools:
           type: array
           items:
-            oneOf:
+            anyOf:
               - type: object
                 properties:
                   name:
@@ -6713,8 +10558,7 @@ components:
                     properties:
                       type:
                         type: string
-                        enum:
-                          - object
+                        default: object
                       properties:
                         nullable: true
                       required:
@@ -6722,8 +10566,6 @@ components:
                         nullable: true
                         items:
                           type: string
-                    required:
-                      - type
                     additionalProperties:
                       nullable: true
                   type:
@@ -6863,6 +10705,78 @@ components:
                 required:
                   - type
                   - name
+              - type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - web_search_20260209
+                  name:
+                    type: string
+                    enum:
+                      - web_search
+                  allowed_callers:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - direct
+                        - code_execution_20250825
+                        - code_execution_20260120
+                  allowed_domains:
+                    type: array
+                    nullable: true
+                    items:
+                      type: string
+                  blocked_domains:
+                    type: array
+                    nullable: true
+                    items:
+                      type: string
+                  max_uses:
+                    type: number
+                    nullable: true
+                  user_location:
+                    type: object
+                    nullable: true
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - approximate
+                      city:
+                        type: string
+                        nullable: true
+                      country:
+                        type: string
+                        nullable: true
+                      region:
+                        type: string
+                        nullable: true
+                      timezone:
+                        type: string
+                        nullable: true
+                    required:
+                      - type
+                  cache_control:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - ephemeral
+                      ttl:
+                        type: string
+                        enum:
+                          - 5m
+                          - 1h
+                    required:
+                      - type
+                required:
+                  - type
+                  - name
+              - $ref: '#/components/schemas/DatetimeServerTool'
+              - $ref: '#/components/schemas/MessagesWebSearchServerTool'
         tool_choice:
           oneOf:
             - type: object
@@ -6927,11 +10841,172 @@ components:
                     - disabled
               required:
                 - type
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - adaptive
+              required:
+                - type
         service_tier:
           type: string
           enum:
             - auto
             - standard_only
+        output_config:
+          $ref: '#/components/schemas/MessagesOutputConfig'
+        cache_control:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - ephemeral
+            ttl:
+              type: string
+              enum:
+                - 5m
+                - 1h
+          required:
+            - type
+        stream:
+          type: boolean
+        context_management:
+          type: object
+          nullable: true
+          properties:
+            edits:
+              type: array
+              items:
+                oneOf:
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - clear_tool_uses_20250919
+                      clear_at_least:
+                        type: object
+                        nullable: true
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - input_tokens
+                          value:
+                            type: number
+                        required:
+                          - type
+                          - value
+                      clear_tool_inputs:
+                        anyOf:
+                          - type: boolean
+                          - type: array
+                            items:
+                              type: string
+                          - nullable: true
+                      exclude_tools:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                      keep:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - tool_uses
+                          value:
+                            type: number
+                        required:
+                          - type
+                          - value
+                      trigger:
+                        oneOf:
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - input_tokens
+                              value:
+                                type: number
+                            required:
+                              - type
+                              - value
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - tool_uses
+                              value:
+                                type: number
+                            required:
+                              - type
+                              - value
+                    required:
+                      - type
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - clear_thinking_20251015
+                      keep:
+                        anyOf:
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - thinking_turns
+                              value:
+                                type: number
+                            required:
+                              - type
+                              - value
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - all
+                            required:
+                              - type
+                          - type: string
+                            enum:
+                              - all
+                    required:
+                      - type
+                  - type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - compact_20260112
+                      instructions:
+                        type: string
+                        nullable: true
+                      pause_after_compaction:
+                        type: boolean
+                      trigger:
+                        type: object
+                        nullable: true
+                        properties:
+                          type:
+                            type: string
+                            enum:
+                              - input_tokens
+                          value:
+                            type: number
+                        required:
+                          - type
+                          - value
+                    required:
+                      - type
         provider:
           type: object
           nullable: true
@@ -7022,13 +11097,21 @@ components:
                 prompt:
                   $ref: '#/components/schemas/BigNumberUnion'
                 completion:
-                  $ref: '#/components/schemas/BigNumberUnion'
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per million completion tokens
                 image:
-                  $ref: '#/components/schemas/BigNumberUnion'
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per image
                 audio:
-                  $ref: '#/components/schemas/BigNumberUnion'
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per audio unit
                 request:
-                  $ref: '#/components/schemas/BigNumberUnion'
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per request
               description: >-
                 The object specifying the maximum price you want to pay for this request. USD price per million tokens,
                 for prompt and completion.
@@ -7088,6 +11171,28 @@ components:
                     type: string
                   engine:
                     $ref: '#/components/schemas/WebSearchEngine'
+                  include_domains:
+                    type: array
+                    items:
+                      type: string
+                    description: >-
+                      A list of domains to restrict web search results to. Supports wildcards (e.g. "*.substack.com")
+                      and path filtering (e.g. "openai.com/blog").
+                    example:
+                      - example.com
+                      - '*.substack.com'
+                      - openai.com/blog
+                  exclude_domains:
+                    type: array
+                    items:
+                      type: string
+                    description: >-
+                      A list of domains to exclude from web search results. Supports wildcards (e.g. "*.substack.com")
+                      and path filtering (e.g. "openai.com/blog").
+                    example:
+                      - example.com
+                      - '*.substack.com'
+                      - openai.com/blog
                 required:
                   - id
               - type: object
@@ -7114,6 +11219,19 @@ components:
                     description: Set to false to disable the response-healing plugin for this request. Defaults to true.
                 required:
                   - id
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - context-compression
+                  enabled:
+                    type: boolean
+                    description: Set to false to disable the context-compression plugin for this request. Defaults to true.
+                  engine:
+                    $ref: '#/components/schemas/ContextCompressionEngine'
+                required:
+                  - id
           description: Plugins you want to enable for this request, including their settings.
         route:
           type: string
@@ -7130,25 +11248,52 @@ components:
           x-fern-ignore: true
         user:
           type: string
-          maxLength: 128
+          maxLength: 256
           description: >-
             A unique identifier representing your end-user, which helps distinguish between different users of your app.
             This allows your app to identify specific users in case of abuse reports, preventing your entire app from
-            being affected by the actions of individual users. Maximum of 128 characters.
+            being affected by the actions of individual users. Maximum of 256 characters.
         session_id:
           type: string
-          maxLength: 128
+          maxLength: 256
           description: >-
             A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for
             observability. If provided in both the request body and the x-session-id header, the body value takes
-            precedence. Maximum of 128 characters.
+            precedence. Maximum of 256 characters.
+        trace:
+          type: object
+          properties:
+            trace_id:
+              type: string
+            trace_name:
+              type: string
+            span_name:
+              type: string
+            generation_name:
+              type: string
+            parent_span_id:
+              type: string
+          additionalProperties:
+            nullable: true
+          description: >-
+            Metadata for observability and tracing. Known keys (trace_id, trace_name, span_name, generation_name,
+            parent_span_id) have special handling. Additional keys are passed through as custom metadata to configured
+            broadcast destinations.
         models:
           type: array
           items:
             type: string
+        speed:
+          type: string
+          enum:
+            - fast
+            - standard
+          description: >-
+            Controls output generation speed. When set to `fast`, uses a higher-speed inference configuration at premium
+            pricing. Defaults to `standard` when omitted.
+          example: fast
       required:
         - model
-        - max_tokens
         - messages
       description: Request schema for Anthropic Messages API endpoint
       example:
@@ -7183,26 +11328,28 @@ components:
           example: OpenAI
         usage:
           type: number
+          format: double
           description: Total cost in USD (OpenRouter credits spent)
           example: 0.015
         byok_usage_inference:
           type: number
+          format: double
           description: BYOK inference cost in USD (external credits spent)
           example: 0.012
         requests:
-          type: number
+          type: integer
           description: Number of requests made
           example: 5
         prompt_tokens:
-          type: number
+          type: integer
           description: Total prompt tokens used
           example: 50
         completion_tokens:
-          type: number
+          type: integer
           description: Total completion tokens generated
           example: 125
         reasoning_tokens:
-          type: number
+          type: integer
           description: Total reasoning tokens used
           example: 25
       required:
@@ -7247,7 +11394,7 @@ components:
       description: Error data for ForbiddenResponse
       example:
         code: 403
-        message: Only provisioning keys can perform this operation
+        message: Only management keys can perform this operation
     ForbiddenResponse:
       type: object
       properties:
@@ -7262,167 +11409,2071 @@ components:
       example:
         error:
           code: 403
-          message: Only provisioning keys can perform this operation
-    CreateChargeRequest:
+          message: Only management keys can perform this operation
+    ChatFinishReasonEnum:
+      type: string
+      enum:
+        - tool_calls
+        - stop
+        - length
+        - content_filter
+        - error
+      example: stop
+    ChatContentCacheControl:
       type: object
       properties:
-        amount:
-          type: number
-        sender:
+        type:
           type: string
-        chain_id:
-          type: integer
           enum:
-            - 1
-            - 137
-            - 8453
+            - ephemeral
+        ttl:
+          type: string
+          enum:
+            - 5m
+            - 1h
       required:
-        - amount
-        - sender
-        - chain_id
-      description: Create a Coinbase charge for crypto payment
+        - type
+      description: Cache control for the content part
       example:
-        amount: 100
-        sender: '0x1234567890123456789012345678901234567890'
-        chain_id: 1
-    ProviderPreferences:
+        type: ephemeral
+        ttl: 5m
+    ChatContentText:
       type: object
       properties:
-        allow_fallbacks:
-          type: boolean
-          nullable: true
-          description: >
-            Whether to allow backup providers to serve requests
-
-            - true: (default) when the primary provider (or your custom providers in "order") is unavailable, use the
-            next best provider.
-
-            - false: use only the primary/custom provider, and return the upstream error if it's unavailable.
-        require_parameters:
-          type: boolean
-          nullable: true
-          description: >-
-            Whether to filter providers to only those that support the parameters you've provided. If this setting is
-            omitted or set to false, then providers will receive only the parameters they support, and ignore the rest.
-        data_collection:
-          $ref: '#/components/schemas/DataCollection'
-        zdr:
-          type: boolean
-          nullable: true
-          description: >-
-            Whether to restrict routing to only ZDR (Zero Data Retention) endpoints. When true, only endpoints that do
-            not retain prompts will be used.
-          example: true
-        enforce_distillable_text:
-          type: boolean
-          nullable: true
-          description: >-
-            Whether to restrict routing to only models that allow text distillation. When true, only models where the
-            author has allowed distillation will be used.
-          example: true
-        order:
-          type: array
-          nullable: true
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/ProviderName'
-              - type: string
-          description: >-
-            An ordered list of provider slugs. The router will attempt to use the first provider in the subset of this
-            list that supports your requested model, and fall back to the next if it is unavailable. If no providers are
-            available, the request will fail with an error message.
-        only:
-          type: array
-          nullable: true
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/ProviderName'
-              - type: string
-          description: >-
-            List of provider slugs to allow. If provided, this list is merged with your account-wide allowed provider
-            settings for this request.
-        ignore:
-          type: array
-          nullable: true
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/ProviderName'
-              - type: string
-          description: >-
-            List of provider slugs to ignore. If provided, this list is merged with your account-wide ignored provider
-            settings for this request.
-        quantizations:
-          type: array
-          nullable: true
-          items:
-            $ref: '#/components/schemas/Quantization'
-          description: A list of quantization levels to filter the provider by.
-        sort:
-          allOf:
-            - $ref: '#/components/schemas/ProviderSort'
-            - anyOf:
-                - $ref: '#/components/schemas/ProviderSort'
-                - $ref: '#/components/schemas/ProviderSortConfig'
-                - nullable: true
-              description: >-
-                The sorting strategy to use for this request, if "order" is not specified. When set, no load balancing
-                is performed.
-        max_price:
+        type:
+          type: string
+          enum:
+            - text
+        text:
+          type: string
+        cache_control:
+          $ref: '#/components/schemas/ChatContentCacheControl'
+      required:
+        - type
+        - text
+      description: Text content part
+      example:
+        type: text
+        text: Hello, world!
+    ChatContentImage:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - image_url
+        image_url:
           type: object
           properties:
-            prompt:
-              $ref: '#/components/schemas/BigNumberUnion'
-            completion:
-              $ref: '#/components/schemas/BigNumberUnion'
-            image:
-              $ref: '#/components/schemas/BigNumberUnion'
-            audio:
-              $ref: '#/components/schemas/BigNumberUnion'
-            request:
-              $ref: '#/components/schemas/BigNumberUnion'
+            url:
+              type: string
+              description: 'URL of the image (data: URLs supported)'
+            detail:
+              type: string
+              enum:
+                - auto
+                - low
+                - high
+              description: Image detail level for vision models
+          required:
+            - url
+      required:
+        - type
+        - image_url
+      description: Image content part for vision models
+      example:
+        type: image_url
+        image_url:
+          url: https://example.com/image.jpg
+          detail: auto
+    ChatContentAudio:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - input_audio
+        input_audio:
+          type: object
+          properties:
+            data:
+              type: string
+              description: Base64 encoded audio data
+            format:
+              type: string
+              description: >-
+                Audio format (e.g., wav, mp3, flac, m4a, ogg, aiff, aac, pcm16, pcm24). Supported formats vary by
+                provider.
+          required:
+            - data
+            - format
+      required:
+        - type
+        - input_audio
+      description: Audio input content part. Supported audio formats vary by provider.
+      example:
+        type: input_audio
+        input_audio:
+          data: SGVsbG8gV29ybGQ=
+          format: wav
+    Legacy_ChatContentVideo:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - input_video
+        video_url:
+          $ref: '#/components/schemas/ChatContentVideoInput'
+      required:
+        - type
+        - video_url
+      description: Video input content part (legacy format - deprecated)
+      deprecated: true
+      example:
+        type: input_video
+        video_url:
+          url: https://example.com/video.mp4
+    ChatContentVideoInput:
+      type: object
+      properties:
+        url:
+          type: string
+          description: 'URL of the video (data: URLs supported)'
+      required:
+        - url
+      description: Video input object
+    ChatContentVideo:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - video_url
+        video_url:
+          $ref: '#/components/schemas/ChatContentVideoInput'
+      required:
+        - type
+        - video_url
+      description: Video input content part
+      example:
+        type: video_url
+        video_url:
+          url: https://example.com/video.mp4
+    ChatContentFile:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - file
+        file:
+          type: object
+          properties:
+            file_data:
+              type: string
+              description: File content as base64 data URL or URL
+            file_id:
+              type: string
+              description: File ID for previously uploaded files
+            filename:
+              type: string
+              description: Original filename
+      required:
+        - type
+        - file
+      description: File content part for document processing
+      example:
+        type: file
+        file:
+          file_data: https://example.com/document.pdf
+          filename: document.pdf
+    ChatContentItems:
+      oneOf:
+        - $ref: '#/components/schemas/ChatContentText'
+        - $ref: '#/components/schemas/ChatContentImage'
+        - $ref: '#/components/schemas/ChatContentAudio'
+        - oneOf:
+            - $ref: '#/components/schemas/Legacy_ChatContentVideo'
+            - $ref: '#/components/schemas/ChatContentVideo'
+          discriminator:
+            propertyName: type
+            mapping:
+              input_video: '#/components/schemas/Legacy_ChatContentVideo'
+              video_url: '#/components/schemas/ChatContentVideo'
+        - $ref: '#/components/schemas/ChatContentFile'
+      discriminator:
+        propertyName: type
+      description: Content part for chat completion messages
+      example:
+        type: text
+        text: Hello, world!
+    ChatToolCall:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Tool call identifier
+        type:
+          type: string
+          enum:
+            - function
+        function:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Function name to call
+            arguments:
+              type: string
+              description: Function arguments as JSON string
+          required:
+            - name
+            - arguments
+      required:
+        - id
+        - type
+        - function
+      description: Tool call made by the assistant
+      example:
+        id: call_abc123
+        type: function
+        function:
+          name: get_current_weather
+          arguments: '{"location": "Boston, MA"}'
+    ReasoningDetailSummary:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - reasoning.summary
+        summary:
+          type: string
+        id:
+          type: string
+          nullable: true
+        format:
+          type: string
+          nullable: true
+          enum:
+            - unknown
+            - openai-responses-v1
+            - azure-openai-responses-v1
+            - xai-responses-v1
+            - anthropic-claude-v1
+            - google-gemini-v1
+        index:
+          type: number
+      required:
+        - type
+        - summary
+      description: Reasoning detail summary schema
+      example:
+        type: reasoning.summary
+        summary: The model analyzed the problem by first identifying key constraints, then evaluating possible solutions...
+    ReasoningDetailEncrypted:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - reasoning.encrypted
+        data:
+          type: string
+        id:
+          type: string
+          nullable: true
+        format:
+          type: string
+          nullable: true
+          enum:
+            - unknown
+            - openai-responses-v1
+            - azure-openai-responses-v1
+            - xai-responses-v1
+            - anthropic-claude-v1
+            - google-gemini-v1
+        index:
+          type: number
+      required:
+        - type
+        - data
+      description: Reasoning detail encrypted schema
+      example:
+        type: reasoning.encrypted
+        data: encrypted data
+    ReasoningDetailText:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - reasoning.text
+        text:
+          type: string
+          nullable: true
+        signature:
+          type: string
+          nullable: true
+        id:
+          type: string
+          nullable: true
+        format:
+          type: string
+          nullable: true
+          enum:
+            - unknown
+            - openai-responses-v1
+            - azure-openai-responses-v1
+            - xai-responses-v1
+            - anthropic-claude-v1
+            - google-gemini-v1
+        index:
+          type: number
+      required:
+        - type
+      description: Reasoning detail text schema
+      example:
+        type: reasoning.text
+        text: The model analyzed the problem by first identifying key constraints, then evaluating possible solutions...
+        signature: signature
+    ReasoningDetailUnion:
+      oneOf:
+        - $ref: '#/components/schemas/ReasoningDetailSummary'
+        - $ref: '#/components/schemas/ReasoningDetailEncrypted'
+        - $ref: '#/components/schemas/ReasoningDetailText'
+      discriminator:
+        propertyName: type
+        mapping:
+          reasoning.summary: '#/components/schemas/ReasoningDetailSummary'
+          reasoning.encrypted: '#/components/schemas/ReasoningDetailEncrypted'
+          reasoning.text: '#/components/schemas/ReasoningDetailText'
+      description: Reasoning detail union schema
+      example:
+        type: reasoning.summary
+        summary: The model analyzed the problem by first identifying key constraints, then evaluating possible solutions...
+    ChatReasoningDetails:
+      type: array
+      items:
+        $ref: '#/components/schemas/ReasoningDetailUnion'
+      description: Reasoning details for extended thinking models
+    ChatAssistantImages:
+      type: array
+      items:
+        type: object
+        properties:
+          image_url:
+            type: object
+            properties:
+              url:
+                type: string
+                description: URL or base64-encoded data of the generated image
+            required:
+              - url
+        required:
+          - image_url
+      description: Generated images from image generation models
+      example:
+        - image_url:
+            url: data:image/png;base64,iVBORw0KGgo...
+    ChatAudioOutput:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Audio output identifier
+        expires_at:
+          type: integer
+          description: Audio expiration timestamp
+        data:
+          type: string
+          description: Base64 encoded audio data
+        transcript:
+          type: string
+          description: Audio transcript
+      description: Audio output data or reference
+      example:
+        id: audio_abc123
+        expires_at: 1677652400
+        data: UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1f
+        transcript: Hello! How can I help you today?
+    ChatAssistantMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - assistant
+        content:
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/ChatContentItems'
+            - nullable: true
+          description: Assistant message content
+        name:
+          type: string
+          description: Optional name for the assistant
+        tool_calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatToolCall'
+          description: Tool calls made by the assistant
+        refusal:
+          type: string
+          nullable: true
+          description: Refusal message if content was refused
+        reasoning:
+          type: string
+          nullable: true
+          description: Reasoning output
+        reasoning_details:
+          $ref: '#/components/schemas/ChatReasoningDetails'
+        images:
+          $ref: '#/components/schemas/ChatAssistantImages'
+        audio:
+          $ref: '#/components/schemas/ChatAudioOutput'
+      required:
+        - role
+      description: Assistant message for requests and responses
+      example:
+        role: assistant
+        content: The capital of France is Paris.
+    ChatTokenLogprob:
+      type: object
+      properties:
+        token:
+          type: string
+          description: The token
+        logprob:
+          type: number
+          format: double
+          description: Log probability of the token
+        bytes:
+          type: array
+          nullable: true
+          items:
+            type: integer
+          description: UTF-8 bytes of the token
+        top_logprobs:
+          type: array
+          items:
+            type: object
+            properties:
+              token:
+                type: string
+              logprob:
+                type: number
+                format: double
+              bytes:
+                type: array
+                nullable: true
+                items:
+                  type: integer
+            required:
+              - token
+              - logprob
+              - bytes
+          description: Top alternative tokens with probabilities
+      required:
+        - token
+        - logprob
+        - bytes
+        - top_logprobs
+      description: Token log probability information
+      example:
+        token: ' Hello'
+        logprob: -0.612345
+        bytes: null
+        top_logprobs:
+          - token: ' Hello'
+            logprob: -0.612345
+            bytes: null
+    ChatTokenLogprobs:
+      type: object
+      nullable: true
+      properties:
+        content:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/ChatTokenLogprob'
+          description: Log probabilities for content tokens
+        refusal:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/ChatTokenLogprob'
+          description: Log probabilities for refusal tokens
+      required:
+        - content
+      description: Log probabilities for the completion
+      example:
+        content:
+          - token: ' Hello'
+            logprob: -0.612345
+            bytes: null
+            top_logprobs: []
+        refusal: null
+    ChatChoice:
+      type: object
+      properties:
+        finish_reason:
+          anyOf:
+            - $ref: '#/components/schemas/ChatFinishReasonEnum'
+            - nullable: true
+            - nullable: true
+        index:
+          type: integer
+          description: Choice index
+          example: 0
+        message:
+          $ref: '#/components/schemas/ChatAssistantMessage'
+        logprobs:
+          $ref: '#/components/schemas/ChatTokenLogprobs'
+      required:
+        - finish_reason
+        - index
+        - message
+      description: Chat completion choice
+      example:
+        finish_reason: stop
+        index: 0
+        message:
+          role: assistant
+          content: The capital of France is Paris.
+        logprobs: null
+    ChatUsage:
+      type: object
+      properties:
+        completion_tokens:
+          type: integer
+          description: Number of tokens in the completion
+        prompt_tokens:
+          type: integer
+          description: Number of tokens in the prompt
+        total_tokens:
+          type: integer
+          description: Total number of tokens
+        completion_tokens_details:
+          type: object
+          nullable: true
+          properties:
+            reasoning_tokens:
+              type: integer
+              description: Tokens used for reasoning
+            audio_tokens:
+              type: integer
+              description: Tokens used for audio output
+            accepted_prediction_tokens:
+              type: integer
+              description: Accepted prediction tokens
+            rejected_prediction_tokens:
+              type: integer
+              description: Rejected prediction tokens
+          description: Detailed completion token usage
+        prompt_tokens_details:
+          type: object
+          nullable: true
+          properties:
+            cached_tokens:
+              type: integer
+              description: Cached prompt tokens
+            cache_write_tokens:
+              type: integer
+              description: Tokens written to cache. Only returned for models with explicit caching and cache write pricing.
+            audio_tokens:
+              type: integer
+              description: Audio input tokens
+            video_tokens:
+              type: integer
+              description: Video input tokens
+          description: Detailed prompt token usage
+      required:
+        - completion_tokens
+        - prompt_tokens
+        - total_tokens
+      description: Token usage statistics
+      example:
+        completion_tokens: 15
+        prompt_tokens: 10
+        total_tokens: 25
+        completion_tokens_details:
+          reasoning_tokens: 5
+        prompt_tokens_details:
+          cached_tokens: 2
+    ChatResult:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique completion identifier
+          example: chatcmpl-123
+        choices:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatChoice'
+          description: List of completion choices
+        created:
+          type: integer
+          description: Unix timestamp of creation
+          example: 1677652288
+        model:
+          type: string
+          description: Model used for completion
+          example: openai/gpt-4
+        object:
+          type: string
+          enum:
+            - chat.completion
+        system_fingerprint:
+          type: string
+          nullable: true
+          description: System fingerprint
+          example: fp_44709d6fcb
+        service_tier:
+          type: string
+          nullable: true
+          description: The service tier used by the upstream provider for this request
+          example: default
+        usage:
+          $ref: '#/components/schemas/ChatUsage'
+      required:
+        - id
+        - choices
+        - created
+        - model
+        - object
+        - system_fingerprint
+      description: Chat completion response
+      example:
+        id: chatcmpl-123
+        object: chat.completion
+        created: 1677652288
+        model: openai/gpt-4
+        choices:
+          - index: 0
+            message:
+              role: assistant
+              content: The capital of France is Paris.
+            finish_reason: stop
+        usage:
+          prompt_tokens: 10
+          completion_tokens: 15
+          total_tokens: 25
+    ChatStreamToolCall:
+      type: object
+      properties:
+        index:
+          type: integer
+          description: Tool call index in the array
+          example: 0
+        id:
+          type: string
+          description: Tool call identifier
+          example: call_abc123
+        type:
+          type: string
+          enum:
+            - function
+          description: Tool call type
+          example: function
+        function:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Function name
+              example: get_weather
+            arguments:
+              type: string
+              description: Function arguments as JSON string
+              example: '{"location":'
+          description: Function call details
+      required:
+        - index
+      description: Tool call delta for streaming responses
+      example:
+        index: 0
+        id: call_abc123
+        type: function
+        function:
+          name: get_weather
+          arguments: '{"location":'
+    ChatStreamDelta:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - assistant
+          description: The role of the message author
+          example: assistant
+        content:
+          type: string
+          nullable: true
+          description: Message content delta
+          example: Hello
+        reasoning:
+          type: string
+          nullable: true
+          description: Reasoning content delta
+          example: I need to
+        refusal:
+          type: string
+          nullable: true
+          description: Refusal message delta
+          example: null
+        tool_calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatStreamToolCall'
+          description: Tool calls delta
+        reasoning_details:
+          $ref: '#/components/schemas/ChatReasoningDetails'
+        audio:
+          allOf:
+            - $ref: '#/components/schemas/ChatAudioOutput'
+            - description: Audio output data
+      description: Delta changes in streaming response
+      example:
+        role: assistant
+        content: Hello
+    ChatStreamChoice:
+      type: object
+      properties:
+        delta:
+          $ref: '#/components/schemas/ChatStreamDelta'
+        finish_reason:
+          anyOf:
+            - $ref: '#/components/schemas/ChatFinishReasonEnum'
+            - nullable: true
+            - nullable: true
+        index:
+          type: integer
+          description: Choice index
+          example: 0
+        logprobs:
+          $ref: '#/components/schemas/ChatTokenLogprobs'
+      required:
+        - delta
+        - finish_reason
+        - index
+      description: Streaming completion choice chunk
+      example:
+        index: 0
+        delta:
+          role: assistant
+          content: Hello
+        finish_reason: null
+    ChatStreamChunk:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique chunk identifier
+          example: chatcmpl-123
+        choices:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatStreamChoice'
+          description: List of streaming chunk choices
+        created:
+          type: integer
+          description: Unix timestamp of creation
+          example: 1677652288
+        model:
+          type: string
+          description: Model used for completion
+          example: openai/gpt-4
+        object:
+          type: string
+          enum:
+            - chat.completion.chunk
+        system_fingerprint:
+          type: string
+          description: System fingerprint
+          example: fp_44709d6fcb
+        service_tier:
+          type: string
+          nullable: true
+          description: The service tier used by the upstream provider for this request
+          example: default
+        error:
+          type: object
+          properties:
+            message:
+              type: string
+              description: Error message
+              example: Rate limit exceeded
+            code:
+              type: integer
+              format: int32
+              description: Error code
+              example: 429
+          required:
+            - message
+            - code
+          description: Error information
+          example:
+            message: Rate limit exceeded
+            code: 429
+        usage:
+          $ref: '#/components/schemas/ChatUsage'
+      required:
+        - id
+        - choices
+        - created
+        - model
+        - object
+      description: Streaming chat completion chunk
+      x-speakeasy-entity: ChatStreamChunk
+      example:
+        id: chatcmpl-123
+        object: chat.completion.chunk
+        created: 1677652288
+        model: openai/gpt-4
+        choices:
+          - index: 0
+            delta:
+              role: assistant
+              content: Hello
+            finish_reason: null
+    ChatSystemMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - system
+        content:
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/ChatContentText'
+          description: System message content
+          example: You are a helpful assistant.
+        name:
+          type: string
+          description: Optional name for the system message
+          example: Assistant Config
+      required:
+        - role
+        - content
+      description: System message for setting behavior
+      example:
+        role: system
+        content: You are a helpful assistant.
+        name: Assistant Config
+    ChatUserMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - user
+        content:
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/ChatContentItems'
+          description: User message content
+          example: What is the capital of France?
+        name:
+          type: string
+          description: Optional name for the user
+          example: User
+      required:
+        - role
+        - content
+      description: User message
+      example:
+        role: user
+        content: What is the capital of France?
+    ChatDeveloperMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - developer
+        content:
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/ChatContentText'
+          description: Developer message content
+          example: This is a message from the developer.
+        name:
+          type: string
+          description: Optional name for the developer message
+          example: Developer
+      required:
+        - role
+        - content
+      description: Developer message
+      example:
+        role: developer
+        content: This is a message from the developer.
+    ChatToolMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - tool
+        content:
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/ChatContentItems'
+          description: Tool response content
+          example: The weather in San Francisco is 72°F and sunny.
+        tool_call_id:
+          type: string
+          description: ID of the assistant message tool call this message responds to
+          example: call_abc123
+      required:
+        - role
+        - content
+        - tool_call_id
+      description: Tool response message
+      example:
+        role: tool
+        content: The weather in San Francisco is 72°F and sunny.
+        tool_call_id: call_abc123
+    ChatMessages:
+      oneOf:
+        - $ref: '#/components/schemas/ChatSystemMessage'
+        - $ref: '#/components/schemas/ChatUserMessage'
+        - $ref: '#/components/schemas/ChatDeveloperMessage'
+        - $ref: '#/components/schemas/ChatAssistantMessage'
+        - $ref: '#/components/schemas/ChatToolMessage'
+      discriminator:
+        propertyName: role
+      description: Chat completion message with role-based discrimination
+      example:
+        role: user
+        content: What is the capital of France?
+    ModelName:
+      type: string
+      description: Model to use for completion
+      example: openai/gpt-4
+    ChatModelNames:
+      type: array
+      items:
+        allOf:
+          - $ref: '#/components/schemas/ModelName'
+          - description: Available OpenRouter chat completion models
+      description: Models to use for completion
+      example:
+        - openai/gpt-4
+        - openai/gpt-4o
+    ChatReasoningSummaryVerbosityEnum:
+      type: string
+      enum:
+        - auto
+        - concise
+        - detailed
+    ChatFormatTextConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - text
+      required:
+        - type
+      description: Default text response format
+      example:
+        type: text
+    ChatJsonSchemaConfig:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+          description: Schema name (a-z, A-Z, 0-9, underscores, dashes, max 64 chars)
+          example: math_response
+        description:
+          type: string
+          description: Schema description for the model
+          example: A mathematical response
+        schema:
+          type: object
+          additionalProperties:
+            nullable: true
+          description: JSON Schema object
+          example:
+            type: object
+            properties:
+              answer:
+                type: number
+            required:
+              - answer
+        strict:
+          type: boolean
+          nullable: true
+          description: Enable strict schema adherence
+          example: false
+      required:
+        - name
+      description: JSON Schema configuration object
+      example:
+        name: math_response
+        description: A mathematical response
+        schema:
+          type: object
+          properties:
+            answer:
+              type: number
+          required:
+            - answer
+        strict: true
+    ChatFormatJsonSchemaConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - json_schema
+        json_schema:
+          $ref: '#/components/schemas/ChatJsonSchemaConfig'
+      required:
+        - type
+        - json_schema
+      description: JSON Schema response format for structured outputs
+      example:
+        type: json_schema
+        json_schema:
+          name: math_response
+          schema:
+            type: object
+            properties:
+              answer:
+                type: number
+            required:
+              - answer
+    ChatFormatGrammarConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - grammar
+        grammar:
+          type: string
+          description: Custom grammar for text generation
+          example: root ::= "yes" | "no"
+      required:
+        - type
+        - grammar
+      description: Custom grammar response format
+      example:
+        type: grammar
+        grammar: root ::= "yes" | "no"
+    ChatFormatPythonConfig:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - python
+      required:
+        - type
+      description: Python code response format
+      example:
+        type: python
+    ChatStreamOptions:
+      type: object
+      nullable: true
+      properties:
+        include_usage:
+          type: boolean
+          description: 'Deprecated: This field has no effect. Full usage details are always included.'
+          example: true
+          deprecated: true
+      description: Streaming configuration options
+      example:
+        include_usage: true
+    ChatNamedToolChoice:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - function
+        function:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Function name to call
+              example: get_weather
+          required:
+            - name
+      required:
+        - type
+        - function
+      description: Named tool choice for specific function
+      example:
+        type: function
+        function:
+          name: get_weather
+    ChatToolChoice:
+      anyOf:
+        - type: string
+          enum:
+            - none
+        - type: string
+          enum:
+            - auto
+        - type: string
+          enum:
+            - required
+        - $ref: '#/components/schemas/ChatNamedToolChoice'
+      description: Tool choice configuration
+      example: auto
+    ChatWebSearchServerTool:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - openrouter:web_search
+        parameters:
+          type: object
+          properties:
+            engine:
+              type: string
+              enum:
+                - auto
+                - native
+                - exa
+                - firecrawl
+                - parallel
+              description: >-
+                Which search engine to use. "auto" (default) uses native if the provider supports it, otherwise Exa.
+                "native" forces the provider's built-in search. "exa" forces the Exa search API. "firecrawl" uses
+                Firecrawl (requires BYOK). "parallel" uses the Parallel search API.
+              example: auto
+            max_results:
+              type: number
+              minimum: 1
+              maximum: 25
+              description: >-
+                Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl,
+                and Parallel engines; ignored with native provider search.
+              example: 5
+            max_total_results:
+              type: number
+              minimum: 1
+              description: >-
+                Maximum total number of search results across all search calls in a single request. Once this limit is
+                reached, the tool will stop returning new results. Useful for controlling cost and context size in
+                agentic loops.
+              example: 20
+            search_context_size:
+              type: string
+              enum:
+                - low
+                - medium
+                - high
+              description: >-
+                How much context to retrieve per result. Defaults to medium (15000 chars). Only applies when using the
+                Exa engine; ignored with native provider search.
+            user_location:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - approximate
+                city:
+                  type: string
+                region:
+                  type: string
+                country:
+                  type: string
+                timezone:
+                  type: string
+              description: Approximate user location for location-biased results.
+            allowed_domains:
+              type: array
+              items:
+                type: string
+              description: >-
+                Limit search results to these domains. Supported by Exa, Parallel, and most native providers (Anthropic,
+                OpenAI, xAI). Not supported with Firecrawl or Perplexity.
+            excluded_domains:
+              type: array
+              items:
+                type: string
+              description: >-
+                Exclude search results from these domains. Supported by Exa, Parallel, Anthropic, and xAI. Not supported
+                with Firecrawl, OpenAI (silently ignored), or Perplexity.
+      required:
+        - type
+      description: 'OpenRouter built-in server tool: searches the web for current information'
+      example:
+        type: openrouter:web_search
+        parameters:
+          engine: auto
+          max_results: 5
+    ChatWebSearchShorthand:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - web_search
+            - web_search_preview
+            - web_search_preview_2025_03_11
+            - web_search_2025_08_26
+        engine:
+          type: string
+          enum:
+            - auto
+            - native
+            - exa
+            - firecrawl
+            - parallel
           description: >-
-            The object specifying the maximum price you want to pay for this request. USD price per million tokens, for
-            prompt and completion.
-        preferred_min_throughput:
-          $ref: '#/components/schemas/PreferredMinThroughput'
-        preferred_max_latency:
-          $ref: '#/components/schemas/PreferredMaxLatency'
-      description: Provider routing preferences for the request.
+            Which search engine to use. "auto" (default) uses native if the provider supports it, otherwise Exa.
+            "native" forces the provider's built-in search. "exa" forces the Exa search API. "firecrawl" uses Firecrawl
+            (requires BYOK). "parallel" uses the Parallel search API.
+          example: auto
+        max_results:
+          type: number
+          minimum: 1
+          maximum: 25
+          description: >-
+            Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl, and
+            Parallel engines; ignored with native provider search.
+          example: 5
+        max_total_results:
+          type: number
+          minimum: 1
+          description: >-
+            Maximum total number of search results across all search calls in a single request. Once this limit is
+            reached, the tool will stop returning new results. Useful for controlling cost and context size in agentic
+            loops.
+          example: 20
+        search_context_size:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+          description: >-
+            How much context to retrieve per result. Defaults to medium (15000 chars). Only applies when using the Exa
+            engine; ignored with native provider search.
+        user_location:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - approximate
+            city:
+              type: string
+            region:
+              type: string
+            country:
+              type: string
+            timezone:
+              type: string
+          description: Approximate user location for location-biased results.
+        allowed_domains:
+          type: array
+          items:
+            type: string
+          description: >-
+            Limit search results to these domains. Supported by Exa, Parallel, and most native providers (Anthropic,
+            OpenAI, xAI). Not supported with Firecrawl or Perplexity.
+        excluded_domains:
+          type: array
+          items:
+            type: string
+          description: >-
+            Exclude search results from these domains. Supported by Exa, Parallel, Anthropic, and xAI. Not supported
+            with Firecrawl, OpenAI (silently ignored), or Perplexity.
+        parameters:
+          type: object
+          properties:
+            engine:
+              type: string
+              enum:
+                - auto
+                - native
+                - exa
+                - firecrawl
+                - parallel
+              description: >-
+                Which search engine to use. "auto" (default) uses native if the provider supports it, otherwise Exa.
+                "native" forces the provider's built-in search. "exa" forces the Exa search API. "firecrawl" uses
+                Firecrawl (requires BYOK). "parallel" uses the Parallel search API.
+              example: auto
+            max_results:
+              type: number
+              minimum: 1
+              maximum: 25
+              description: >-
+                Maximum number of search results to return per search call. Defaults to 5. Applies to Exa, Firecrawl,
+                and Parallel engines; ignored with native provider search.
+              example: 5
+            max_total_results:
+              type: number
+              minimum: 1
+              description: >-
+                Maximum total number of search results across all search calls in a single request. Once this limit is
+                reached, the tool will stop returning new results. Useful for controlling cost and context size in
+                agentic loops.
+              example: 20
+            search_context_size:
+              type: string
+              enum:
+                - low
+                - medium
+                - high
+              description: >-
+                How much context to retrieve per result. Defaults to medium (15000 chars). Only applies when using the
+                Exa engine; ignored with native provider search.
+            user_location:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - approximate
+                city:
+                  type: string
+                region:
+                  type: string
+                country:
+                  type: string
+                timezone:
+                  type: string
+              description: Approximate user location for location-biased results.
+            allowed_domains:
+              type: array
+              items:
+                type: string
+              description: >-
+                Limit search results to these domains. Supported by Exa, Parallel, and most native providers (Anthropic,
+                OpenAI, xAI). Not supported with Firecrawl or Perplexity.
+            excluded_domains:
+              type: array
+              items:
+                type: string
+              description: >-
+                Exclude search results from these domains. Supported by Exa, Parallel, Anthropic, and xAI. Not supported
+                with Firecrawl, OpenAI (silently ignored), or Perplexity.
+      required:
+        - type
+      description: Web search tool using OpenAI Responses API syntax. Automatically converted to openrouter:web_search.
+    ChatFunctionTool:
+      anyOf:
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - function
+            function:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 64
+                  description: Function name (a-z, A-Z, 0-9, underscores, dashes, max 64 chars)
+                  example: get_weather
+                description:
+                  type: string
+                  description: Function description for the model
+                  example: Get the current weather for a location
+                parameters:
+                  type: object
+                  additionalProperties:
+                    nullable: true
+                  description: Function parameters as JSON Schema object
+                  example:
+                    type: object
+                    properties:
+                      location:
+                        type: string
+                        description: City name
+                    required:
+                      - location
+                strict:
+                  type: boolean
+                  nullable: true
+                  description: Enable strict schema adherence
+                  example: false
+              required:
+                - name
+              description: Function definition for tool calling
+              example:
+                name: get_weather
+                description: Get the current weather for a location
+                parameters:
+                  type: object
+                  properties:
+                    location:
+                      type: string
+                      description: City name
+                  required:
+                    - location
+            cache_control:
+              $ref: '#/components/schemas/ChatContentCacheControl'
+          required:
+            - type
+            - function
+        - $ref: '#/components/schemas/DatetimeServerTool'
+        - $ref: '#/components/schemas/ChatWebSearchServerTool'
+        - $ref: '#/components/schemas/ChatWebSearchShorthand'
+      description: Tool definition for function calling (regular function or OpenRouter built-in server tool)
+      example:
+        type: function
+        function:
+          name: get_weather
+          description: Get the current weather for a location
+          parameters:
+            type: object
+            properties:
+              location:
+                type: string
+                description: City name
+              unit:
+                type: string
+                enum:
+                  - celsius
+                  - fahrenheit
+            required:
+              - location
+    ChatDebugOptions:
+      type: object
+      properties:
+        echo_upstream_body:
+          type: boolean
+          description: >-
+            If true, includes the transformed upstream request body in a debug chunk at the start of the stream. Only
+            works with streaming mode.
+          example: true
+      description: Debug options for inspecting request transformations (streaming only)
+      example:
+        echo_upstream_body: true
+    ChatRequest:
+      type: object
+      properties:
+        provider:
+          type: object
+          nullable: true
+          properties:
+            allow_fallbacks:
+              type: boolean
+              nullable: true
+              description: >
+                Whether to allow backup providers to serve requests
+
+                - true: (default) when the primary provider (or your custom providers in "order") is unavailable, use
+                the next best provider.
+
+                - false: use only the primary/custom provider, and return the upstream error if it's unavailable.
+            require_parameters:
+              type: boolean
+              nullable: true
+              description: >-
+                Whether to filter providers to only those that support the parameters you've provided. If this setting
+                is omitted or set to false, then providers will receive only the parameters they support, and ignore the
+                rest.
+            data_collection:
+              $ref: '#/components/schemas/DataCollection'
+            zdr:
+              type: boolean
+              nullable: true
+              description: >-
+                Whether to restrict routing to only ZDR (Zero Data Retention) endpoints. When true, only endpoints that
+                do not retain prompts will be used.
+              example: true
+            enforce_distillable_text:
+              type: boolean
+              nullable: true
+              description: >-
+                Whether to restrict routing to only models that allow text distillation. When true, only models where
+                the author has allowed distillation will be used.
+              example: true
+            order:
+              type: array
+              nullable: true
+              items:
+                anyOf:
+                  - $ref: '#/components/schemas/ProviderName'
+                  - type: string
+              description: >-
+                An ordered list of provider slugs. The router will attempt to use the first provider in the subset of
+                this list that supports your requested model, and fall back to the next if it is unavailable. If no
+                providers are available, the request will fail with an error message.
+            only:
+              type: array
+              nullable: true
+              items:
+                anyOf:
+                  - $ref: '#/components/schemas/ProviderName'
+                  - type: string
+              description: >-
+                List of provider slugs to allow. If provided, this list is merged with your account-wide allowed
+                provider settings for this request.
+            ignore:
+              type: array
+              nullable: true
+              items:
+                anyOf:
+                  - $ref: '#/components/schemas/ProviderName'
+                  - type: string
+              description: >-
+                List of provider slugs to ignore. If provided, this list is merged with your account-wide ignored
+                provider settings for this request.
+            quantizations:
+              type: array
+              nullable: true
+              items:
+                $ref: '#/components/schemas/Quantization'
+              description: A list of quantization levels to filter the provider by.
+            sort:
+              allOf:
+                - $ref: '#/components/schemas/ProviderSort'
+                - anyOf:
+                    - $ref: '#/components/schemas/ProviderSort'
+                    - $ref: '#/components/schemas/ProviderSortConfig'
+                    - nullable: true
+                  description: >-
+                    The sorting strategy to use for this request, if "order" is not specified. When set, no load
+                    balancing is performed.
+            max_price:
+              type: object
+              properties:
+                prompt:
+                  $ref: '#/components/schemas/BigNumberUnion'
+                completion:
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per million completion tokens
+                image:
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per image
+                audio:
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per audio unit
+                request:
+                  allOf:
+                    - $ref: '#/components/schemas/BigNumberUnion'
+                    - description: Price per request
+              description: >-
+                The object specifying the maximum price you want to pay for this request. USD price per million tokens,
+                for prompt and completion.
+            preferred_min_throughput:
+              $ref: '#/components/schemas/PreferredMinThroughput'
+            preferred_max_latency:
+              $ref: '#/components/schemas/PreferredMaxLatency'
+          additionalProperties: false
+          description: When multiple model providers are available, optionally indicate your routing preference.
+        plugins:
+          type: array
+          items:
+            oneOf:
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - auto-router
+                  enabled:
+                    type: boolean
+                    description: Set to false to disable the auto-router plugin for this request. Defaults to true.
+                  allowed_models:
+                    type: array
+                    items:
+                      type: string
+                    description: >-
+                      List of model patterns to filter which models the auto-router can route between. Supports
+                      wildcards (e.g., "anthropic/*" matches all Anthropic models). When not specified, uses the default
+                      supported models list.
+                    example:
+                      - anthropic/*
+                      - openai/gpt-4o
+                      - google/*
+                required:
+                  - id
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - moderation
+                required:
+                  - id
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - web
+                  enabled:
+                    type: boolean
+                    description: Set to false to disable the web-search plugin for this request. Defaults to true.
+                  max_results:
+                    type: number
+                  search_prompt:
+                    type: string
+                  engine:
+                    $ref: '#/components/schemas/WebSearchEngine'
+                  include_domains:
+                    type: array
+                    items:
+                      type: string
+                    description: >-
+                      A list of domains to restrict web search results to. Supports wildcards (e.g. "*.substack.com")
+                      and path filtering (e.g. "openai.com/blog").
+                    example:
+                      - example.com
+                      - '*.substack.com'
+                      - openai.com/blog
+                  exclude_domains:
+                    type: array
+                    items:
+                      type: string
+                    description: >-
+                      A list of domains to exclude from web search results. Supports wildcards (e.g. "*.substack.com")
+                      and path filtering (e.g. "openai.com/blog").
+                    example:
+                      - example.com
+                      - '*.substack.com'
+                      - openai.com/blog
+                required:
+                  - id
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - file-parser
+                  enabled:
+                    type: boolean
+                    description: Set to false to disable the file-parser plugin for this request. Defaults to true.
+                  pdf:
+                    $ref: '#/components/schemas/PDFParserOptions'
+                required:
+                  - id
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - response-healing
+                  enabled:
+                    type: boolean
+                    description: Set to false to disable the response-healing plugin for this request. Defaults to true.
+                required:
+                  - id
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - context-compression
+                  enabled:
+                    type: boolean
+                    description: Set to false to disable the context-compression plugin for this request. Defaults to true.
+                  engine:
+                    $ref: '#/components/schemas/ContextCompressionEngine'
+                required:
+                  - id
+          description: Plugins you want to enable for this request, including their settings.
+        route:
+          type: string
+          nullable: true
+          enum:
+            - fallback
+            - sort
+          deprecated: true
+          description: >-
+            **DEPRECATED** Use providers.sort.partition instead. Backwards-compatible alias for
+            providers.sort.partition. Accepts legacy values: "fallback" (maps to "model"), "sort" (maps to "none").
+          x-speakeasy-deprecation-message: Use providers.sort.partition instead.
+          x-speakeasy-ignore: true
+          x-fern-ignore: true
+        user:
+          type: string
+          description: Unique user identifier
+          example: user-123
+        session_id:
+          type: string
+          maxLength: 256
+          description: >-
+            A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for
+            observability. If provided in both the request body and the x-session-id header, the body value takes
+            precedence. Maximum of 256 characters.
+        trace:
+          type: object
+          properties:
+            trace_id:
+              type: string
+            trace_name:
+              type: string
+            span_name:
+              type: string
+            generation_name:
+              type: string
+            parent_span_id:
+              type: string
+          additionalProperties:
+            nullable: true
+          description: >-
+            Metadata for observability and tracing. Known keys (trace_id, trace_name, span_name, generation_name,
+            parent_span_id) have special handling. Additional keys are passed through as custom metadata to configured
+            broadcast destinations.
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatMessages'
+          minItems: 1
+          description: List of messages for the conversation
+          example:
+            - role: user
+              content: Hello!
+        model:
+          $ref: '#/components/schemas/ModelName'
+        models:
+          $ref: '#/components/schemas/ChatModelNames'
+        frequency_penalty:
+          type: number
+          format: double
+          description: Frequency penalty (-2.0 to 2.0)
+          example: 0
+        logit_bias:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: number
+            format: double
+          description: Token logit bias adjustments
+          example:
+            '50256': -100
+        logprobs:
+          type: boolean
+          nullable: true
+          description: Return log probabilities
+          example: false
+        top_logprobs:
+          type: integer
+          description: Number of top log probabilities to return (0-20)
+          example: 5
+        max_completion_tokens:
+          type: integer
+          description: Maximum tokens in completion
+          example: 100
+        max_tokens:
+          type: integer
+          description: 'Maximum tokens (deprecated, use max_completion_tokens). Note: some providers enforce a minimum of 16.'
+          example: 100
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: Key-value pairs for additional object information (max 16 pairs, 64 char keys, 512 char values)
+          example:
+            user_id: user-123
+            session_id: session-456
+        presence_penalty:
+          type: number
+          format: double
+          description: Presence penalty (-2.0 to 2.0)
+          example: 0
+        reasoning:
+          type: object
+          properties:
+            effort:
+              type: string
+              nullable: true
+              enum:
+                - xhigh
+                - high
+                - medium
+                - low
+                - minimal
+                - none
+              description: Constrains effort on reasoning for reasoning models
+              example: medium
+            summary:
+              anyOf:
+                - $ref: '#/components/schemas/ChatReasoningSummaryVerbosityEnum'
+                - nullable: true
+                - nullable: true
+          description: Configuration options for reasoning models
+          example:
+            effort: medium
+            summary: concise
+        response_format:
+          oneOf:
+            - $ref: '#/components/schemas/ChatFormatTextConfig'
+            - $ref: '#/components/schemas/FormatJsonObjectConfig'
+            - $ref: '#/components/schemas/ChatFormatJsonSchemaConfig'
+            - $ref: '#/components/schemas/ChatFormatGrammarConfig'
+            - $ref: '#/components/schemas/ChatFormatPythonConfig'
+          discriminator:
+            propertyName: type
+          description: Response format configuration
+          example:
+            type: json_object
+        seed:
+          type: integer
+          description: Random seed for deterministic outputs
+          example: 42
+        stop:
+          anyOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+              maxItems: 4
+            - nullable: true
+          description: Stop sequences (up to 4)
+          example:
+            - |+
+
+        stream:
+          type: boolean
+          default: false
+          description: Enable streaming response
+          example: false
+        stream_options:
+          $ref: '#/components/schemas/ChatStreamOptions'
+        temperature:
+          type: number
+          format: double
+          description: Sampling temperature (0-2)
+          example: 0.7
+        parallel_tool_calls:
+          type: boolean
+          nullable: true
+          description: >-
+            Whether to enable parallel function calling during tool use. When true, the model may generate multiple tool
+            calls in a single response.
+          example: true
+        tool_choice:
+          $ref: '#/components/schemas/ChatToolChoice'
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatFunctionTool'
+          description: Available tools for function calling
+          example:
+            - type: function
+              function:
+                name: get_weather
+                description: Get weather
+        top_p:
+          type: number
+          format: double
+          description: Nucleus sampling parameter (0-1)
+          example: 1
+        debug:
+          $ref: '#/components/schemas/ChatDebugOptions'
+        image_config:
+          type: object
+          additionalProperties:
+            anyOf:
+              - type: string
+              - type: number
+                format: double
+              - type: array
+                items:
+                  nullable: true
+          description: >-
+            Provider-specific image configuration options. Keys and values vary by model/provider. See
+            https://openrouter.ai/docs/guides/overview/multimodal/image-generation for more details.
+          example:
+            aspect_ratio: '16:9'
+        modalities:
+          type: array
+          items:
+            type: string
+            enum:
+              - text
+              - image
+              - audio
+          description: Output modalities for the response. Supported values are "text", "image", and "audio".
+          example:
+            - text
+            - image
+        cache_control:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - ephemeral
+            ttl:
+              type: string
+              enum:
+                - 5m
+                - 1h
+          required:
+            - type
+          description: >-
+            Enable automatic prompt caching. When set, the system automatically applies cache breakpoints to the last
+            cacheable block in the request. Currently supported for Anthropic Claude models.
+        service_tier:
+          type: string
+          nullable: true
+          enum:
+            - auto
+            - default
+            - flex
+            - priority
+            - scale
+          description: The service tier to use for processing this request.
+          example: auto
+      required:
+        - messages
+      description: Chat completion request parameters
+      example:
+        messages:
+          - role: system
+            content: You are a helpful assistant.
+          - role: user
+            content: What is the capital of France?
+        model: openai/gpt-4
+        temperature: 0.7
+        max_tokens: 150
+    GoneResponseErrorData:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties:
+            nullable: true
+      required:
+        - code
+        - message
+      description: Error data for GoneResponse
+      example:
+        code: 410
+        message: >-
+          The Coinbase APIs used by this endpoint have been deprecated, so the Coinbase Commerce credits API has been
+          removed. Use the web credits purchase flow instead.
+    GoneResponse:
+      type: object
+      properties:
+        error:
+          $ref: '#/components/schemas/GoneResponseErrorData'
+        user_id:
+          type: string
+          nullable: true
+      required:
+        - error
+      description: Gone - Endpoint has been permanently removed or deprecated
+      example:
+        error:
+          code: 410
+          message: >-
+            The Coinbase APIs used by this endpoint have been deprecated, so the Coinbase Commerce credits API has been
+            removed. Use the web credits purchase flow instead.
+    ModelsCountResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            count:
+              type: integer
+              description: Total number of available models
+              example: 150
+          required:
+            - count
+          description: Model count data
+          example:
+            count: 150
+      required:
+        - data
+      description: Model count data
+      example:
+        data:
+          count: 150
     PublicPricing:
       type: object
       properties:
         prompt:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         completion:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         request:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         image:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         image_token:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         image_output:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         audio:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         audio_output:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         input_audio_cache:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         web_search:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         internal_reasoning:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         input_cache_read:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         input_cache_write:
-          $ref: '#/components/schemas/BigNumberUnion'
+          allOf:
+            - $ref: '#/components/schemas/BigNumberUnion'
+            - description: A number or string value representing a large number
         discount:
           type: number
       required:
         - prompt
         - completion
-      additionalProperties: false
       description: Pricing information for the model
       example:
         prompt: '0.00003'
@@ -7438,6 +13489,7 @@ components:
         - GPT
         - Claude
         - Gemini
+        - Gemma
         - Grok
         - Cohere
         - Nova
@@ -7469,6 +13521,7 @@ components:
         - image
         - embeddings
         - audio
+        - video
       example: text
     ModelArchitecture:
       type: object
@@ -7535,13 +13588,11 @@ components:
       type: object
       properties:
         context_length:
-          type: number
-          nullable: true
+          type: integer
           description: Context length from the top provider
           example: 8192
         max_completion_tokens:
-          type: number
-          nullable: true
+          type: integer
           description: Maximum completion tokens from the top provider
           example: 4096
         is_moderated:
@@ -7608,25 +13659,32 @@ components:
       properties:
         temperature:
           type: number
-          nullable: true
-          minimum: 0
-          maximum: 2
+          format: double
         top_p:
           type: number
+          format: double
+        top_k:
+          type: integer
           nullable: true
           minimum: 0
-          maximum: 1
         frequency_penalty:
           type: number
-          nullable: true
-          minimum: -2
-          maximum: 2
+          format: double
+        presence_penalty:
+          type: number
+          format: double
+        repetition_penalty:
+          type: number
+          format: double
       additionalProperties: false
       description: Default parameters for this model
       example:
         temperature: 0.7
         top_p: 0.9
+        top_k: 0
         frequency_penalty: 0
+        presence_penalty: 0
+        repetition_penalty: 1
     Model:
       type: object
       properties:
@@ -7648,7 +13706,7 @@ components:
           description: Display name of the model
           example: GPT-4
         created:
-          type: number
+          type: integer
           description: Unix timestamp of when the model was created
           example: 1692901234
         description:
@@ -7658,8 +13716,7 @@ components:
         pricing:
           $ref: '#/components/schemas/PublicPricing'
         context_length:
-          type: number
-          nullable: true
+          type: integer
           description: Maximum context length in tokens
           example: 8192
         architecture:
@@ -7675,6 +13732,11 @@ components:
           description: List of supported parameters for this model
         default_parameters:
           $ref: '#/components/schemas/DefaultParameters'
+        knowledge_cutoff:
+          type: string
+          nullable: true
+          description: The date up to which the model was trained on data. ISO 8601 date string (YYYY-MM-DD) or null if unknown.
+          example: '2024-10-01'
         expiration_date:
           type: string
           nullable: true
@@ -7723,6 +13785,7 @@ components:
           - top_p
           - max_tokens
         default_parameters: null
+        knowledge_cutoff: null
         expiration_date: null
     ModelsListResponseData:
       type: array
@@ -7770,28 +13833,8 @@ components:
               - frequency_penalty
               - presence_penalty
             default_parameters: null
+            knowledge_cutoff: null
             expiration_date: null
-    ModelsCountResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          properties:
-            count:
-              type: number
-              description: Total number of available models
-              example: 150
-          required:
-            - count
-          description: Model count data
-          example:
-            count: 150
-      required:
-        - data
-      description: Model count data
-      example:
-        data:
-          count: 150
     InstructType:
       type: string
       nullable: true
@@ -7874,37 +13917,62 @@ components:
           type: object
           properties:
             prompt:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             completion:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             request:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             image:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             image_token:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             image_output:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             audio:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             audio_output:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             input_audio_cache:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             web_search:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             internal_reasoning:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             input_cache_read:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             input_cache_write:
-              $ref: '#/components/schemas/BigNumberUnion'
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: A number or string value representing a large number
             discount:
               type: number
           required:
             - prompt
             - completion
-          additionalProperties: false
         provider_name:
           $ref: '#/components/schemas/ProviderName'
         tag:
@@ -7928,6 +13996,18 @@ components:
         uptime_last_30m:
           type: number
           nullable: true
+        uptime_last_5m:
+          type: number
+          nullable: true
+          description: >-
+            Uptime percentage over the last 5 minutes, calculated as successful requests / (successful + error requests)
+            * 100. Rate-limited requests are excluded. Returns null if insufficient data.
+        uptime_last_1d:
+          type: number
+          nullable: true
+          description: >-
+            Uptime percentage over the last 1 day, calculated as successful requests / (successful + error requests) *
+            100. Rate-limited requests are excluded. Returns null if insufficient data.
         supports_implicit_caching:
           type: boolean
         latency_last_30m:
@@ -7952,6 +14032,8 @@ components:
         - max_prompt_tokens
         - supported_parameters
         - uptime_last_30m
+        - uptime_last_5m
+        - uptime_last_1d
         - supports_implicit_caching
         - latency_last_30m
         - throughput_last_30m
@@ -7977,6 +14059,8 @@ components:
           - max_tokens
         status: 0
         uptime_last_30m: 99.5
+        uptime_last_5m: 100
+        uptime_last_1d: 99.8
         supports_implicit_caching: true
         latency_last_30m:
           p50: 0.25
@@ -8000,7 +14084,7 @@ components:
           description: Display name of the model
           example: GPT-4
         created:
-          type: number
+          type: integer
           description: Unix timestamp of when the model was created
           example: 1692901234
         description:
@@ -8090,6 +14174,8 @@ components:
               - presence_penalty
             status: default
             uptime_last_30m: 99.5
+            uptime_last_5m: 100
+            uptime_last_1d: 99.8
             supports_implicit_caching: true
             latency_last_30m:
               p50: 0.25
@@ -8101,1246 +14187,151 @@ components:
               p75: 38.5
               p90: 28.3
               p99: 15.1
-    __schema0:
-      type: array
-      items:
-        anyOf:
-          - type: string
-            enum:
-              - AI21
-              - AionLabs
-              - Alibaba
-              - Amazon Bedrock
-              - Amazon Nova
-              - Anthropic
-              - Arcee AI
-              - AtlasCloud
-              - Avian
-              - Azure
-              - BaseTen
-              - BytePlus
-              - Black Forest Labs
-              - Cerebras
-              - Chutes
-              - Cirrascale
-              - Clarifai
-              - Cloudflare
-              - Cohere
-              - Crusoe
-              - DeepInfra
-              - DeepSeek
-              - Featherless
-              - Fireworks
-              - Friendli
-              - GMICloud
-              - Google
-              - Google AI Studio
-              - Groq
-              - Hyperbolic
-              - Inception
-              - Inceptron
-              - InferenceNet
-              - Infermatic
-              - Inflection
-              - Liquid
-              - Mara
-              - Mancer 2
-              - Minimax
-              - ModelRun
-              - Mistral
-              - Modular
-              - Moonshot AI
-              - Morph
-              - NCompass
-              - Nebius
-              - NextBit
-              - Novita
-              - Nvidia
-              - OpenAI
-              - OpenInference
-              - Parasail
-              - Perplexity
-              - Phala
-              - Relace
-              - SambaNova
-              - Seed
-              - SiliconFlow
-              - Sourceful
-              - Stealth
-              - StreamLake
-              - Switchpoint
-              - Together
-              - Upstage
-              - Venice
-              - WandB
-              - Xiaomi
-              - xAI
-              - Z.AI
-              - FakeProvider
-          - type: string
-    __schema1:
-      anyOf:
-        - type: number
-        - type: string
-        - type: number
-    __schema2:
-      oneOf:
-        - type: object
-          properties:
-            type:
-              type: string
-              const: reasoning.summary
-            summary:
-              type: string
-            id:
-              $ref: '#/components/schemas/__schema3'
-            format:
-              $ref: '#/components/schemas/__schema4'
-            index:
-              $ref: '#/components/schemas/__schema5'
-          required:
-            - type
-            - summary
-        - type: object
-          properties:
-            type:
-              type: string
-              const: reasoning.encrypted
-            data:
-              type: string
-            id:
-              $ref: '#/components/schemas/__schema3'
-            format:
-              $ref: '#/components/schemas/__schema4'
-            index:
-              $ref: '#/components/schemas/__schema5'
-          required:
-            - type
-            - data
-        - type: object
-          properties:
-            type:
-              type: string
-              const: reasoning.text
-            text:
-              anyOf:
-                - type: string
-                - type: 'null'
-            signature:
-              anyOf:
-                - type: string
-                - type: 'null'
-            id:
-              $ref: '#/components/schemas/__schema3'
-            format:
-              $ref: '#/components/schemas/__schema4'
-            index:
-              $ref: '#/components/schemas/__schema5'
-          required:
-            - type
-      type: object
-    __schema3:
-      anyOf:
-        - type: string
-        - type: 'null'
-    __schema4:
-      anyOf:
-        - type: string
-          enum:
-            - unknown
-            - openai-responses-v1
-            - azure-openai-responses-v1
-            - xai-responses-v1
-            - anthropic-claude-v1
-            - google-gemini-v1
-        - type: 'null'
-    __schema5:
-      type: number
-    __schema6:
-      anyOf:
-        - $ref: '#/components/schemas/ChatCompletionFinishReason'
-        - type: 'null'
-    ModelName:
-      type: string
-    ChatMessageContentItemText:
+    ConflictResponseErrorData:
       type: object
       properties:
-        type:
+        code:
+          type: integer
+        message:
           type: string
-          const: text
-        text:
-          type: string
-        cache_control:
-          $ref: '#/components/schemas/ChatMessageContentItemCacheControl'
-      required:
-        - type
-        - text
-    ChatMessageContentItemImage:
-      type: object
-      properties:
-        type:
-          type: string
-          const: image_url
-        image_url:
-          type: object
-          properties:
-            url:
-              type: string
-            detail:
-              type: string
-              enum:
-                - auto
-                - low
-                - high
-          required:
-            - url
-      required:
-        - type
-        - image_url
-    ChatMessageContentItemAudio:
-      type: object
-      properties:
-        type:
-          type: string
-          const: input_audio
-        input_audio:
-          type: object
-          properties:
-            data:
-              type: string
-            format:
-              type: string
-          required:
-            - data
-            - format
-      required:
-        - type
-        - input_audio
-    ChatMessageContentItemVideo:
-      oneOf:
-        - type: object
-          properties:
-            type:
-              type: string
-              const: input_video
-            video_url:
-              type: object
-              properties:
-                url:
-                  type: string
-              required:
-                - url
-          required:
-            - type
-            - video_url
-        - type: object
-          properties:
-            type:
-              type: string
-              const: video_url
-            video_url:
-              type: object
-              properties:
-                url:
-                  type: string
-              required:
-                - url
-          required:
-            - type
-            - video_url
-      type: object
-    ChatMessageContentItem:
-      oneOf:
-        - $ref: '#/components/schemas/ChatMessageContentItemText'
-        - $ref: '#/components/schemas/ChatMessageContentItemImage'
-        - $ref: '#/components/schemas/ChatMessageContentItemAudio'
-        - $ref: '#/components/schemas/ChatMessageContentItemVideo'
-      type: object
-      discriminator:
-        propertyName: type
-        mapping:
-          text: '#/components/schemas/ChatMessageContentItemText'
-          image_url: '#/components/schemas/ChatMessageContentItemImage'
-          input_audio: '#/components/schemas/ChatMessageContentItemAudio'
-          input_video: '#/components/schemas/ChatMessageContentItemVideo'
-          video_url: '#/components/schemas/ChatMessageContentItemVideo'
-    ChatMessageToolCall:
-      type: object
-      properties:
-        id:
-          type: string
-        type:
-          type: string
-          const: function
-        function:
-          type: object
-          properties:
-            name:
-              type: string
-            arguments:
-              type: string
-          required:
-            - name
-            - arguments
-      required:
-        - id
-        - type
-        - function
-    ChatMessageTokenLogprob:
-      type: object
-      properties:
-        token:
-          type: string
-        logprob:
-          type: number
-        bytes:
-          anyOf:
-            - type: array
-              items:
-                type: number
-            - type: 'null'
-        top_logprobs:
-          type: array
-          items:
-            type: object
-            properties:
-              token:
-                type: string
-              logprob:
-                type: number
-              bytes:
-                anyOf:
-                  - type: array
-                    items:
-                      type: number
-                  - type: 'null'
-            required:
-              - token
-              - logprob
-              - bytes
-      required:
-        - token
-        - logprob
-        - bytes
-        - top_logprobs
-    ChatMessageTokenLogprobs:
-      type: object
-      properties:
-        content:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/ChatMessageTokenLogprob'
-            - type: 'null'
-        refusal:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/ChatMessageTokenLogprob'
-            - type: 'null'
-      required:
-        - content
-        - refusal
-    ChatGenerationTokenUsage:
-      type: object
-      properties:
-        completion_tokens:
-          type: number
-        prompt_tokens:
-          type: number
-        total_tokens:
-          type: number
-        completion_tokens_details:
-          anyOf:
-            - type: object
-              properties:
-                reasoning_tokens:
-                  anyOf:
-                    - type: number
-                    - type: 'null'
-                audio_tokens:
-                  anyOf:
-                    - type: number
-                    - type: 'null'
-                accepted_prediction_tokens:
-                  anyOf:
-                    - type: number
-                    - type: 'null'
-                rejected_prediction_tokens:
-                  anyOf:
-                    - type: number
-                    - type: 'null'
-            - type: 'null'
-        prompt_tokens_details:
-          anyOf:
-            - type: object
-              properties:
-                cached_tokens:
-                  type: number
-                cache_write_tokens:
-                  type: number
-                audio_tokens:
-                  type: number
-                video_tokens:
-                  type: number
-            - type: 'null'
-      required:
-        - completion_tokens
-        - prompt_tokens
-        - total_tokens
-    ChatCompletionFinishReason:
-      type: string
-      enum:
-        - tool_calls
-        - stop
-        - length
-        - content_filter
-        - error
-    JSONSchemaConfig:
-      type: object
-      properties:
-        name:
-          type: string
-          maxLength: 64
-        description:
-          type: string
-        schema:
-          type: object
-          propertyNames:
-            type: string
-          additionalProperties: {}
-        strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
-      required:
-        - name
-    ResponseFormatJSONSchema:
-      type: object
-      properties:
-        type:
-          type: string
-          const: json_schema
-        json_schema:
-          $ref: '#/components/schemas/JSONSchemaConfig'
-      required:
-        - type
-        - json_schema
-    ResponseFormatTextGrammar:
-      type: object
-      properties:
-        type:
-          type: string
-          const: grammar
-        grammar:
-          type: string
-      required:
-        - type
-        - grammar
-    ChatMessageContentItemCacheControl:
-      type: object
-      properties:
-        type:
-          type: string
-          const: ephemeral
-        ttl:
-          type: string
-          enum:
-            - 5m
-            - 1h
-      required:
-        - type
-    SystemMessage:
-      type: object
-      properties:
-        role:
-          type: string
-          const: system
-        content:
-          anyOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/ChatMessageContentItemText'
-        name:
-          type: string
-      required:
-        - role
-        - content
-    UserMessage:
-      type: object
-      properties:
-        role:
-          type: string
-          const: user
-        content:
-          anyOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/ChatMessageContentItem'
-        name:
-          type: string
-      required:
-        - role
-        - content
-    AssistantMessage:
-      type: object
-      properties:
-        role:
-          type: string
-          const: assistant
-        content:
-          anyOf:
-            - anyOf:
-                - type: string
-                - type: array
-                  items:
-                    $ref: '#/components/schemas/ChatMessageContentItem'
-            - type: 'null'
-        name:
-          type: string
-        tool_calls:
-          type: array
-          items:
-            $ref: '#/components/schemas/ChatMessageToolCall'
-        refusal:
-          anyOf:
-            - type: string
-            - type: 'null'
-        reasoning:
-          anyOf:
-            - type: string
-            - type: 'null'
-        reasoning_details:
-          type: array
-          items:
-            $ref: '#/components/schemas/__schema2'
-        images:
-          type: array
-          items:
-            type: object
-            properties:
-              image_url:
-                type: object
-                properties:
-                  url:
-                    type: string
-                required:
-                  - url
-            required:
-              - image_url
-      required:
-        - role
-    ToolResponseMessage:
-      type: object
-      properties:
-        role:
-          type: string
-          const: tool
-        content:
-          anyOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/ChatMessageContentItem'
-        tool_call_id:
-          type: string
-      required:
-        - role
-        - content
-        - tool_call_id
-    Message:
-      oneOf:
-        - $ref: '#/components/schemas/SystemMessage'
-        - $ref: '#/components/schemas/UserMessage'
-        - type: object
-          properties:
-            role:
-              type: string
-              const: developer
-            content:
-              anyOf:
-                - type: string
-                - type: array
-                  items:
-                    $ref: '#/components/schemas/ChatMessageContentItemText'
-            name:
-              type: string
-          required:
-            - role
-            - content
-        - $ref: '#/components/schemas/AssistantMessage'
-        - $ref: '#/components/schemas/ToolResponseMessage'
-      type: object
-    ToolDefinitionJson:
-      type: object
-      properties:
-        type:
-          type: string
-          const: function
-        function:
-          type: object
-          properties:
-            name:
-              type: string
-              maxLength: 64
-            description:
-              type: string
-            parameters:
-              type: object
-              propertyNames:
-                type: string
-              additionalProperties: {}
-            strict:
-              anyOf:
-                - type: boolean
-                - type: 'null'
-          required:
-            - name
-      required:
-        - type
-        - function
-    NamedToolChoice:
-      type: object
-      properties:
-        type:
-          type: string
-          const: function
-        function:
-          type: object
-          properties:
-            name:
-              type: string
-          required:
-            - name
-      required:
-        - type
-        - function
-    ToolChoiceOption:
-      anyOf:
-        - type: string
-          const: none
-        - type: string
-          const: auto
-        - type: string
-          const: required
-        - $ref: '#/components/schemas/NamedToolChoice'
-    ChatStreamOptions:
-      type: object
-      properties:
-        include_usage:
-          type: boolean
-    ChatGenerationParams:
-      type: object
-      properties:
-        provider:
-          description: When multiple model providers are available, optionally indicate your routing preference.
-          anyOf:
-            - type: object
-              properties:
-                allow_fallbacks:
-                  description: >
-                    Whether to allow backup providers to serve requests
-
-                    - true: (default) when the primary provider (or your custom providers in "order") is unavailable,
-                    use the next best provider.
-
-                    - false: use only the primary/custom provider, and return the upstream error if it's unavailable.
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                require_parameters:
-                  description: >-
-                    Whether to filter providers to only those that support the parameters you've provided. If this
-                    setting is omitted or set to false, then providers will receive only the parameters they support,
-                    and ignore the rest.
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                data_collection:
-                  description: >-
-                    Data collection setting. If no available model provider meets the requirement, your request will
-                    return an error.
-
-                    - allow: (default) allow providers which store user data non-transiently and may train on it
-
-
-                    - deny: use only providers which do not collect user data.
-                  anyOf:
-                    - type: string
-                      enum:
-                        - deny
-                        - allow
-                    - type: 'null'
-                zdr:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                enforce_distillable_text:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                order:
-                  description: >-
-                    An ordered list of provider slugs. The router will attempt to use the first provider in the subset
-                    of this list that supports your requested model, and fall back to the next if it is unavailable. If
-                    no providers are available, the request will fail with an error message.
-                  anyOf:
-                    - $ref: '#/components/schemas/__schema0'
-                    - type: 'null'
-                only:
-                  description: >-
-                    List of provider slugs to allow. If provided, this list is merged with your account-wide allowed
-                    provider settings for this request.
-                  anyOf:
-                    - $ref: '#/components/schemas/__schema0'
-                    - type: 'null'
-                ignore:
-                  description: >-
-                    List of provider slugs to ignore. If provided, this list is merged with your account-wide ignored
-                    provider settings for this request.
-                  anyOf:
-                    - $ref: '#/components/schemas/__schema0'
-                    - type: 'null'
-                quantizations:
-                  description: A list of quantization levels to filter the provider by.
-                  anyOf:
-                    - type: array
-                      items:
-                        type: string
-                        enum:
-                          - int4
-                          - int8
-                          - fp4
-                          - fp6
-                          - fp8
-                          - fp16
-                          - bf16
-                          - fp32
-                          - unknown
-                    - type: 'null'
-                sort:
-                  description: >-
-                    The sorting strategy to use for this request, if "order" is not specified. When set, no load
-                    balancing is performed.
-                  anyOf:
-                    - $ref: '#/components/schemas/ProviderSortUnion'
-                    - type: 'null'
-                max_price:
-                  description: >-
-                    The object specifying the maximum price you want to pay for this request. USD price per million
-                    tokens, for prompt and completion.
-                  type: object
-                  properties:
-                    prompt:
-                      $ref: '#/components/schemas/__schema1'
-                    completion:
-                      $ref: '#/components/schemas/__schema1'
-                    image:
-                      $ref: '#/components/schemas/__schema1'
-                    audio:
-                      $ref: '#/components/schemas/__schema1'
-                    request:
-                      $ref: '#/components/schemas/__schema1'
-                preferred_min_throughput:
-                  description: >-
-                    Preferred minimum throughput (in tokens per second). Can be a number (applies to p50) or an object
-                    with percentile-specific cutoffs. Endpoints below the threshold(s) may still be used, but are
-                    deprioritized in routing. When using fallback models, this may cause a fallback model to be used
-                    instead of the primary model if it meets the threshold.
-                  anyOf:
-                    - anyOf:
-                        - type: number
-                        - type: object
-                          properties:
-                            p50:
-                              anyOf:
-                                - type: number
-                                - type: 'null'
-                            p75:
-                              anyOf:
-                                - type: number
-                                - type: 'null'
-                            p90:
-                              anyOf:
-                                - type: number
-                                - type: 'null'
-                            p99:
-                              anyOf:
-                                - type: number
-                                - type: 'null'
-                    - type: 'null'
-                preferred_max_latency:
-                  description: >-
-                    Preferred maximum latency (in seconds). Can be a number (applies to p50) or an object with
-                    percentile-specific cutoffs. Endpoints above the threshold(s) may still be used, but are
-                    deprioritized in routing. When using fallback models, this may cause a fallback model to be used
-                    instead of the primary model if it meets the threshold.
-                  anyOf:
-                    - anyOf:
-                        - type: number
-                        - type: object
-                          properties:
-                            p50:
-                              anyOf:
-                                - type: number
-                                - type: 'null'
-                            p75:
-                              anyOf:
-                                - type: number
-                                - type: 'null'
-                            p90:
-                              anyOf:
-                                - type: number
-                                - type: 'null'
-                            p99:
-                              anyOf:
-                                - type: number
-                                - type: 'null'
-                    - type: 'null'
-              additionalProperties: false
-            - type: 'null'
-        plugins:
-          description: Plugins you want to enable for this request, including their settings.
-          type: array
-          items:
-            oneOf:
-              - type: object
-                properties:
-                  id:
-                    type: string
-                    const: auto-router
-                  enabled:
-                    type: boolean
-                  allowed_models:
-                    type: array
-                    items:
-                      type: string
-                required:
-                  - id
-              - type: object
-                properties:
-                  id:
-                    type: string
-                    const: moderation
-                required:
-                  - id
-              - type: object
-                properties:
-                  id:
-                    type: string
-                    const: web
-                  enabled:
-                    type: boolean
-                  max_results:
-                    type: number
-                  search_prompt:
-                    type: string
-                  engine:
-                    type: string
-                    enum:
-                      - native
-                      - exa
-                required:
-                  - id
-              - type: object
-                properties:
-                  id:
-                    type: string
-                    const: file-parser
-                  enabled:
-                    type: boolean
-                  pdf:
-                    type: object
-                    properties:
-                      engine:
-                        type: string
-                        enum:
-                          - mistral-ocr
-                          - pdf-text
-                          - native
-                required:
-                  - id
-              - type: object
-                properties:
-                  id:
-                    type: string
-                    const: response-healing
-                  enabled:
-                    type: boolean
-                required:
-                  - id
-            type: object
-        route:
-          anyOf:
-            - type: string
-              enum:
-                - fallback
-                - sort
-            - type: 'null'
-        user:
-          type: string
-        session_id:
-          description: >-
-            A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for
-            observability. If provided in both the request body and the x-session-id header, the body value takes
-            precedence. Maximum of 128 characters.
-          type: string
-          maxLength: 128
-        messages:
-          minItems: 1
-          type: array
-          items:
-            $ref: '#/components/schemas/Message'
-        model:
-          $ref: '#/components/schemas/ModelName'
-        models:
-          type: array
-          items:
-            $ref: '#/components/schemas/ModelName'
-        frequency_penalty:
-          anyOf:
-            - type: number
-              minimum: -2
-              maximum: 2
-            - type: 'null'
-        logit_bias:
-          anyOf:
-            - type: object
-              propertyNames:
-                type: string
-              additionalProperties:
-                type: number
-            - type: 'null'
-        logprobs:
-          anyOf:
-            - type: boolean
-            - type: 'null'
-        top_logprobs:
-          anyOf:
-            - type: number
-              minimum: 0
-              maximum: 20
-            - type: 'null'
-        max_completion_tokens:
-          anyOf:
-            - type: number
-              minimum: 1
-            - type: 'null'
-        max_tokens:
-          anyOf:
-            - type: number
-              minimum: 1
-            - type: 'null'
         metadata:
           type: object
-          propertyNames:
-            type: string
+          nullable: true
           additionalProperties:
-            type: string
-        presence_penalty:
-          anyOf:
-            - type: number
-              minimum: -2
-              maximum: 2
-            - type: 'null'
-        reasoning:
-          type: object
-          properties:
-            effort:
-              anyOf:
-                - type: string
-                  enum:
-                    - xhigh
-                    - high
-                    - medium
-                    - low
-                    - minimal
-                    - none
-                - type: 'null'
-            summary:
-              anyOf:
-                - $ref: '#/components/schemas/ReasoningSummaryVerbosity'
-                - type: 'null'
-        response_format:
-          oneOf:
-            - type: object
-              properties:
-                type:
-                  type: string
-                  const: text
-              required:
-                - type
-            - type: object
-              properties:
-                type:
-                  type: string
-                  const: json_object
-              required:
-                - type
-            - $ref: '#/components/schemas/ResponseFormatJSONSchema'
-            - $ref: '#/components/schemas/ResponseFormatTextGrammar'
-            - type: object
-              properties:
-                type:
-                  type: string
-                  const: python
-              required:
-                - type
-          type: object
-        seed:
-          anyOf:
-            - type: integer
-              minimum: -9007199254740991
-              maximum: 9007199254740991
-            - type: 'null'
-        stop:
-          anyOf:
-            - anyOf:
-                - type: string
-                - maxItems: 4
-                  type: array
-                  items:
-                    type: string
-            - type: 'null'
-        stream:
-          default: false
-          type: boolean
-        stream_options:
-          anyOf:
-            - $ref: '#/components/schemas/ChatStreamOptions'
-            - type: 'null'
-        temperature:
-          default: 1
-          anyOf:
-            - type: number
-              minimum: 0
-              maximum: 2
-            - type: 'null'
-        tool_choice:
-          $ref: '#/components/schemas/ToolChoiceOption'
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/ToolDefinitionJson'
-        top_p:
-          default: 1
-          anyOf:
-            - type: number
-              minimum: 0
-              maximum: 1
-            - type: 'null'
-        debug:
-          type: object
-          properties:
-            echo_upstream_body:
-              type: boolean
-        image_config:
-          type: object
-          propertyNames:
-            type: string
-          additionalProperties:
-            anyOf:
-              - type: string
-              - type: number
-        modalities:
-          type: array
-          items:
-            type: string
-            enum:
-              - text
-              - image
+            nullable: true
       required:
-        - messages
-    ProviderSortUnion:
-      anyOf:
-        - $ref: '#/components/schemas/ProviderSort'
-        - $ref: '#/components/schemas/ProviderSortConfig'
-    ChatResponseChoice:
-      type: object
-      properties:
-        finish_reason:
-          $ref: '#/components/schemas/__schema6'
-        index:
-          type: number
-        message:
-          $ref: '#/components/schemas/AssistantMessage'
-        logprobs:
-          anyOf:
-            - $ref: '#/components/schemas/ChatMessageTokenLogprobs'
-            - type: 'null'
-      required:
-        - finish_reason
-        - index
+        - code
         - message
-    ChatStreamingMessageToolCall:
-      type: object
-      properties:
-        index:
-          type: number
-        id:
-          type: string
-        type:
-          type: string
-          const: function
-        function:
-          type: object
-          properties:
-            name:
-              type: string
-            arguments:
-              type: string
-      required:
-        - index
-    ChatStreamingMessageChunk:
-      type: object
-      properties:
-        role:
-          type: string
-          enum:
-            - assistant
-        content:
-          anyOf:
-            - type: string
-            - type: 'null'
-        reasoning:
-          anyOf:
-            - type: string
-            - type: 'null'
-        refusal:
-          anyOf:
-            - type: string
-            - type: 'null'
-        tool_calls:
-          type: array
-          items:
-            $ref: '#/components/schemas/ChatStreamingMessageToolCall'
-        reasoning_details:
-          type: array
-          items:
-            $ref: '#/components/schemas/__schema2'
-    ChatStreamingChoice:
-      type: object
-      properties:
-        delta:
-          $ref: '#/components/schemas/ChatStreamingMessageChunk'
-        finish_reason:
-          $ref: '#/components/schemas/__schema6'
-        index:
-          type: number
-        logprobs:
-          anyOf:
-            - $ref: '#/components/schemas/ChatMessageTokenLogprobs'
-            - type: 'null'
-      required:
-        - delta
-        - finish_reason
-        - index
-    ChatError:
+      description: Error data for ConflictResponse
+      example:
+        code: 409
+        message: Resource conflict. Please try again later.
+    ConflictResponse:
       type: object
       properties:
         error:
-          type: object
-          properties:
-            code:
-              anyOf:
-                - anyOf:
-                    - type: string
-                    - type: number
-                - type: 'null'
-            message:
-              type: string
-            param:
-              anyOf:
-                - type: string
-                - type: 'null'
-            type:
-              anyOf:
-                - type: string
-                - type: 'null'
-          required:
-            - code
-            - message
-          additionalProperties: false
+          $ref: '#/components/schemas/ConflictResponseErrorData'
+        user_id:
+          type: string
+          nullable: true
       required:
         - error
-      additionalProperties: false
-    ChatResponse:
+      description: Conflict - Resource conflict or concurrent modification
+      example:
+        error:
+          code: 409
+          message: Resource conflict. Please try again later.
+    ProviderPreferences:
       type: object
       properties:
-        id:
-          type: string
-        choices:
+        allow_fallbacks:
+          type: boolean
+          nullable: true
+          description: >
+            Whether to allow backup providers to serve requests
+
+            - true: (default) when the primary provider (or your custom providers in "order") is unavailable, use the
+            next best provider.
+
+            - false: use only the primary/custom provider, and return the upstream error if it's unavailable.
+        require_parameters:
+          type: boolean
+          nullable: true
+          description: >-
+            Whether to filter providers to only those that support the parameters you've provided. If this setting is
+            omitted or set to false, then providers will receive only the parameters they support, and ignore the rest.
+        data_collection:
+          $ref: '#/components/schemas/DataCollection'
+        zdr:
+          type: boolean
+          nullable: true
+          description: >-
+            Whether to restrict routing to only ZDR (Zero Data Retention) endpoints. When true, only endpoints that do
+            not retain prompts will be used.
+          example: true
+        enforce_distillable_text:
+          type: boolean
+          nullable: true
+          description: >-
+            Whether to restrict routing to only models that allow text distillation. When true, only models where the
+            author has allowed distillation will be used.
+          example: true
+        order:
           type: array
+          nullable: true
           items:
-            $ref: '#/components/schemas/ChatResponseChoice'
-        created:
-          type: number
-        model:
-          type: string
-        object:
-          type: string
-          const: chat.completion
-        system_fingerprint:
-          anyOf:
-            - type: string
-            - type: 'null'
-        usage:
-          $ref: '#/components/schemas/ChatGenerationTokenUsage'
-      required:
-        - id
-        - choices
-        - created
-        - model
-        - object
-      additionalProperties: false
-    ChatStreamingResponseChunk:
-      type: object
-      properties:
-        data:
+            anyOf:
+              - $ref: '#/components/schemas/ProviderName'
+              - type: string
+          description: >-
+            An ordered list of provider slugs. The router will attempt to use the first provider in the subset of this
+            list that supports your requested model, and fall back to the next if it is unavailable. If no providers are
+            available, the request will fail with an error message.
+        only:
+          type: array
+          nullable: true
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/ProviderName'
+              - type: string
+          description: >-
+            List of provider slugs to allow. If provided, this list is merged with your account-wide allowed provider
+            settings for this request.
+        ignore:
+          type: array
+          nullable: true
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/ProviderName'
+              - type: string
+          description: >-
+            List of provider slugs to ignore. If provided, this list is merged with your account-wide ignored provider
+            settings for this request.
+        quantizations:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/Quantization'
+          description: A list of quantization levels to filter the provider by.
+        sort:
+          allOf:
+            - $ref: '#/components/schemas/ProviderSort'
+            - anyOf:
+                - $ref: '#/components/schemas/ProviderSort'
+                - $ref: '#/components/schemas/ProviderSortConfig'
+                - nullable: true
+              description: >-
+                The sorting strategy to use for this request, if "order" is not specified. When set, no load balancing
+                is performed.
+        max_price:
           type: object
           properties:
-            id:
-              type: string
-            choices:
-              type: array
-              items:
-                $ref: '#/components/schemas/ChatStreamingChoice'
-            created:
-              type: number
-            model:
-              type: string
-            object:
-              type: string
-              const: chat.completion.chunk
-            system_fingerprint:
-              anyOf:
-                - type: string
-                - type: 'null'
-            error:
-              type: object
-              properties:
-                message:
-                  type: string
-                code:
-                  type: number
-              required:
-                - message
-                - code
-              additionalProperties: false
-            usage:
-              $ref: '#/components/schemas/ChatGenerationTokenUsage'
-          required:
-            - id
-            - choices
-            - created
-            - model
-            - object
-          additionalProperties: false
-      required:
-        - data
-      additionalProperties: false
+            prompt:
+              $ref: '#/components/schemas/BigNumberUnion'
+            completion:
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: Price per million completion tokens
+            image:
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: Price per image
+            audio:
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: Price per audio unit
+            request:
+              allOf:
+                - $ref: '#/components/schemas/BigNumberUnion'
+                - description: Price per request
+          description: >-
+            The object specifying the maximum price you want to pay for this request. USD price per million tokens, for
+            prompt and completion.
+        preferred_min_throughput:
+          $ref: '#/components/schemas/PreferredMinThroughput'
+        preferred_max_latency:
+          $ref: '#/components/schemas/PreferredMaxLatency'
+      description: Provider routing preferences for the request.
   parameters: {}
   securitySchemes:
     apiKey:
@@ -9364,7 +14355,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OpenResponsesRequest'
+              $ref: '#/components/schemas/ResponsesRequest'
         required: true
       responses:
         '200':
@@ -9372,13 +14363,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OpenResponsesNonStreamingResponse'
+                $ref: '#/components/schemas/OpenResponsesResult'
             text/event-stream:
               schema:
                 type: object
                 properties:
                   data:
-                    $ref: '#/components/schemas/OpenResponsesStreamEvent'
+                    $ref: '#/components/schemas/StreamEvents'
                 required:
                   - data
               x-speakeasy-sse-sentinel: '[DONE]'
@@ -9467,7 +14458,7 @@ paths:
       x-speakeasy-name-override: create
       x-speakeasy-stream-request-field: stream
       tags:
-        - anthropic.messages
+        - Anthropic Messages
       summary: Create a message
       description: >-
         Creates a message using the Anthropic Messages API format. Supports text, images, PDFs, tools, and extended
@@ -9476,7 +14467,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AnthropicMessagesRequest'
+              $ref: '#/components/schemas/MessagesRequest'
         required: true
       responses:
         '200':
@@ -9484,7 +14475,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AnthropicMessagesResponse'
+                $ref: '#/components/schemas/MessagesResult'
             text/event-stream:
               schema:
                 type: object
@@ -9492,7 +14483,7 @@ paths:
                   event:
                     type: string
                   data:
-                    $ref: '#/components/schemas/AnthropicMessagesStreamEvent'
+                    $ref: '#/components/schemas/MessagesStreamEvents'
                 required:
                   - event
                   - data
@@ -9697,8 +14688,8 @@ paths:
       operationId: getUserActivity
       summary: Get user activity grouped by endpoint
       description: >-
-        Returns user activity data grouped by endpoint for the last 30 (completed) UTC days. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
+        Returns user activity data grouped by endpoint for the last 30 (completed) UTC days. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
       parameters:
         - schema:
             type: string
@@ -9707,6 +14698,22 @@ paths:
           required: false
           description: Filter by a single UTC date in the last 30 days (YYYY-MM-DD format).
           name: date
+          in: query
+        - schema:
+            type: string
+            description: Filter by API key hash (SHA-256 hex string, as returned by the keys API).
+            example: abc123def456...
+          required: false
+          description: Filter by API key hash (SHA-256 hex string, as returned by the keys API).
+          name: api_key_hash
+          in: query
+        - schema:
+            type: string
+            description: Filter by org member user ID. Only applicable for organization accounts.
+            example: user_abc123
+          required: false
+          description: Filter by org member user ID. Only applicable for organization accounts.
+          name: user_id
           in: query
       responses:
         '200':
@@ -9749,17 +14756,135 @@ paths:
               schema:
                 $ref: '#/components/schemas/UnauthorizedResponse'
         '403':
-          description: Forbidden - Only provisioning keys can fetch activity
+          description: Forbidden - Only management keys can fetch activity
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+        '404':
+          description: Not Found - User is not a member of the organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
         '500':
           description: Internal Server Error - Unexpected server error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalServerResponse'
+  /chat/completions:
+    post:
+      x-speakeasy-group: chat
+      x-speakeasy-name-override: send
+      x-speakeasy-stream-request-field: stream
+      tags:
+        - Chat
+      summary: Create a chat completion
+      operationId: sendChatCompletionRequest
+      description: >-
+        Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming
+        modes.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful chat completion response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatResult'
+            text/event-stream:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ChatStreamChunk'
+                required:
+                  - data
+              x-speakeasy-sse-sentinel: '[DONE]'
+        '400':
+          description: Bad Request - Invalid request parameters or malformed input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Authentication required or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '402':
+          description: Payment Required - Insufficient credits or quota to complete request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentRequiredResponse'
+        '404':
+          description: Not Found - Resource does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '408':
+          description: Request Timeout - Operation exceeded time limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestTimeoutResponse'
+        '413':
+          description: Payload Too Large - Request payload exceeds size limits
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PayloadTooLargeResponse'
+        '422':
+          description: Unprocessable Entity - Semantic validation failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnprocessableEntityResponse'
+        '429':
+          description: Too Many Requests - Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TooManyRequestsResponse'
+        '500':
+          description: Internal Server Error - Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+        '502':
+          description: Bad Gateway - Provider/upstream API failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadGatewayResponse'
+        '503':
+          description: Service Unavailable - Service temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableResponse'
+        '524':
+          description: Infrastructure Timeout - Request timed out at our edge network
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeNetworkTimeoutResponse'
+        '529':
+          description: Provider Overloaded - Provider is temporarily overloaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderOverloadedResponse'
   /credits:
     get:
       x-speakeasy-name-override: getCredits
@@ -9768,8 +14893,8 @@ paths:
       summary: Get remaining credits
       operationId: getCredits
       description: >-
-        Get total credits purchased and used for the authenticated user. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
+        Get total credits purchased and used for the authenticated user. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
       responses:
         '200':
           description: Returns the total credits purchased and used
@@ -9783,10 +14908,12 @@ paths:
                     properties:
                       total_credits:
                         type: number
+                        format: double
                         description: Total credits purchased
                         example: 100.5
                       total_usage:
                         type: number
+                        format: double
                         description: Total credits used
                         example: 25.75
                     required:
@@ -9809,7 +14936,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UnauthorizedResponse'
         '403':
-          description: Forbidden - Only provisioning keys can fetch credits
+          description: Forbidden - Only management keys can fetch credits
           content:
             application/json:
               schema:
@@ -9822,23 +14949,38 @@ paths:
                 $ref: '#/components/schemas/InternalServerResponse'
   /credits/coinbase:
     post:
-      security:
-        - bearer: []
+      security: []
       x-speakeasy-name-override: createCoinbaseCharge
+      deprecated: true
       tags:
         - Credits
-      summary: Create a Coinbase charge for crypto payment
+      summary: Deprecated Coinbase Commerce charge endpoint
       operationId: createCoinbaseCharge
-      description: Create a Coinbase charge for crypto payment
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateChargeRequest'
-        required: true
+      description: >-
+        Deprecated. The Coinbase APIs used by this endpoint have been deprecated, so Coinbase Commerce charges have been
+        removed. Use the web credits purchase flow instead.
+      responses:
+        '410':
+          description: Gone - Coinbase Commerce charge creation has been removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GoneResponse'
+  /generation:
+    get:
+      tags:
+        - Generations
+      summary: Get request & usage metadata for a generation
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: id
+          in: query
       responses:
         '200':
-          description: Returns the calldata to fulfill the transaction
+          description: Returns the request metadata for this generation
           content:
             application/json:
               schema:
@@ -9849,87 +14991,356 @@ paths:
                     properties:
                       id:
                         type: string
+                        description: Unique identifier for the generation
+                        example: gen-3bhGkxlo4XFrqiabUM7NDtwDzWwG
+                      upstream_id:
+                        type: string
+                        nullable: true
+                        description: Upstream provider's identifier for this generation
+                        example: chatcmpl-791bcf62-080e-4568-87d0-94c72e3b4946
+                      total_cost:
+                        type: number
+                        format: double
+                        description: Total cost of the generation in USD
+                        example: 0.0015
+                      cache_discount:
+                        type: number
+                        format: double
+                        description: Discount applied due to caching
+                        example: 0.0002
+                      upstream_inference_cost:
+                        type: number
+                        format: double
+                        description: Cost charged by the upstream provider
+                        example: 0.0012
                       created_at:
                         type: string
-                      expires_at:
+                        description: ISO 8601 timestamp of when the generation was created
+                        example: '2024-07-15T23:33:19.433273+00:00'
+                      model:
                         type: string
-                      web3_data:
-                        type: object
-                        properties:
-                          transfer_intent:
-                            type: object
-                            properties:
-                              call_data:
-                                type: object
-                                properties:
-                                  deadline:
-                                    type: string
-                                  fee_amount:
-                                    type: string
-                                  id:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  prefix:
-                                    type: string
-                                  recipient:
-                                    type: string
-                                  recipient_amount:
-                                    type: string
-                                  recipient_currency:
-                                    type: string
-                                  refund_destination:
-                                    type: string
-                                  signature:
-                                    type: string
-                                required:
-                                  - deadline
-                                  - fee_amount
-                                  - id
-                                  - operator
-                                  - prefix
-                                  - recipient
-                                  - recipient_amount
-                                  - recipient_currency
-                                  - refund_destination
-                                  - signature
-                              metadata:
-                                type: object
-                                properties:
-                                  chain_id:
-                                    type: number
-                                  contract_address:
-                                    type: string
-                                  sender:
-                                    type: string
-                                required:
-                                  - chain_id
-                                  - contract_address
-                                  - sender
-                            required:
-                              - call_data
-                              - metadata
-                        required:
-                          - transfer_intent
+                        description: Model used for the generation
+                        example: sao10k/l3-stheno-8b
+                      app_id:
+                        type: integer
+                        description: ID of the app that made the request
+                        example: 12345
+                      streamed:
+                        type: boolean
+                        nullable: true
+                        description: Whether the response was streamed
+                        example: true
+                      cancelled:
+                        type: boolean
+                        nullable: true
+                        description: Whether the generation was cancelled
+                        example: false
+                      provider_name:
+                        type: string
+                        nullable: true
+                        description: Name of the provider that served the request
+                        example: Infermatic
+                      latency:
+                        type: number
+                        format: double
+                        description: Total latency in milliseconds
+                        example: 1250
+                      moderation_latency:
+                        type: number
+                        format: double
+                        description: Moderation latency in milliseconds
+                        example: 50
+                      generation_time:
+                        type: number
+                        format: double
+                        description: Time taken for generation in milliseconds
+                        example: 1200
+                      finish_reason:
+                        type: string
+                        nullable: true
+                        description: Reason the generation finished
+                        example: stop
+                      tokens_prompt:
+                        type: integer
+                        description: Number of tokens in the prompt
+                        example: 10
+                      tokens_completion:
+                        type: integer
+                        description: Number of tokens in the completion
+                        example: 25
+                      native_tokens_prompt:
+                        type: integer
+                        description: Native prompt tokens as reported by provider
+                        example: 10
+                      native_tokens_completion:
+                        type: integer
+                        description: Native completion tokens as reported by provider
+                        example: 25
+                      native_tokens_completion_images:
+                        type: integer
+                        description: Native completion image tokens as reported by provider
+                        example: 0
+                      native_tokens_reasoning:
+                        type: integer
+                        description: Native reasoning tokens as reported by provider
+                        example: 5
+                      native_tokens_cached:
+                        type: integer
+                        description: Native cached tokens as reported by provider
+                        example: 3
+                      num_media_prompt:
+                        type: integer
+                        description: Number of media items in the prompt
+                        example: 1
+                      num_input_audio_prompt:
+                        type: integer
+                        description: Number of audio inputs in the prompt
+                        example: 0
+                      num_media_completion:
+                        type: integer
+                        description: Number of media items in the completion
+                        example: 0
+                      num_search_results:
+                        type: integer
+                        description: Number of search results included
+                        example: 5
+                      origin:
+                        type: string
+                        description: Origin URL of the request
+                        example: https://openrouter.ai/
+                      usage:
+                        type: number
+                        format: double
+                        description: Usage amount in USD
+                        example: 0.0015
+                      is_byok:
+                        type: boolean
+                        description: Whether this used bring-your-own-key
+                        example: false
+                      native_finish_reason:
+                        type: string
+                        nullable: true
+                        description: Native finish reason as reported by provider
+                        example: stop
+                      external_user:
+                        type: string
+                        nullable: true
+                        description: External user identifier
+                        example: user-123
+                      api_type:
+                        type: string
+                        nullable: true
+                        enum:
+                          - completions
+                          - embeddings
+                          - video
+                        description: Type of API used for the generation
+                      router:
+                        type: string
+                        nullable: true
+                        description: Router used for the request (e.g., openrouter/auto)
+                        example: openrouter/auto
+                      provider_responses:
+                        type: array
+                        nullable: true
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            endpoint_id:
+                              type: string
+                            model_permaslug:
+                              type: string
+                            provider_name:
+                              type: string
+                              enum:
+                                - AnyScale
+                                - Atoma
+                                - Cent-ML
+                                - CrofAI
+                                - Enfer
+                                - GoPomelo
+                                - HuggingFace
+                                - Hyperbolic 2
+                                - InoCloud
+                                - Kluster
+                                - Lambda
+                                - Lepton
+                                - Lynn 2
+                                - Lynn
+                                - Mancer
+                                - Meta
+                                - Modal
+                                - Nineteen
+                                - OctoAI
+                                - Recursal
+                                - Reflection
+                                - Replicate
+                                - SambaNova 2
+                                - SF Compute
+                                - Targon
+                                - Together 2
+                                - Ubicloud
+                                - 01.AI
+                                - AkashML
+                                - AI21
+                                - AionLabs
+                                - Alibaba
+                                - Ambient
+                                - Amazon Bedrock
+                                - Amazon Nova
+                                - Anthropic
+                                - Arcee AI
+                                - AtlasCloud
+                                - Avian
+                                - Azure
+                                - BaseTen
+                                - BytePlus
+                                - Black Forest Labs
+                                - Cerebras
+                                - Chutes
+                                - Cirrascale
+                                - Clarifai
+                                - Cloudflare
+                                - Cohere
+                                - Crusoe
+                                - DeepInfra
+                                - DeepSeek
+                                - Featherless
+                                - Fireworks
+                                - Friendli
+                                - GMICloud
+                                - Google
+                                - Google AI Studio
+                                - Groq
+                                - Hyperbolic
+                                - Inception
+                                - Inceptron
+                                - InferenceNet
+                                - Ionstream
+                                - Infermatic
+                                - Io Net
+                                - Inflection
+                                - Liquid
+                                - Mara
+                                - Mancer 2
+                                - Minimax
+                                - ModelRun
+                                - Mistral
+                                - Modular
+                                - Moonshot AI
+                                - Morph
+                                - NCompass
+                                - Nebius
+                                - NextBit
+                                - Novita
+                                - Nvidia
+                                - OpenAI
+                                - OpenInference
+                                - Parasail
+                                - Perplexity
+                                - Phala
+                                - Reka
+                                - Relace
+                                - SambaNova
+                                - Seed
+                                - SiliconFlow
+                                - Sourceful
+                                - StepFun
+                                - Stealth
+                                - StreamLake
+                                - Switchpoint
+                                - Together
+                                - Upstage
+                                - Venice
+                                - WandB
+                                - Xiaomi
+                                - xAI
+                                - Z.AI
+                                - FakeProvider
+                            status:
+                              type: number
+                              nullable: true
+                            latency:
+                              type: number
+                            is_byok:
+                              type: boolean
+                          required:
+                            - status
+                        description: List of provider responses for this generation, including fallback attempts
+                      user_agent:
+                        type: string
+                        nullable: true
+                        description: User-Agent header from the request
+                      http_referer:
+                        type: string
+                        nullable: true
+                        description: Referer header from the request
+                      request_id:
+                        type: string
+                        nullable: true
+                        description: Unique identifier grouping all generations from a single API request
+                        example: req-1727282430-aBcDeFgHiJkLmNoPqRsT
                     required:
                       - id
+                      - upstream_id
+                      - total_cost
+                      - cache_discount
+                      - upstream_inference_cost
                       - created_at
-                      - expires_at
-                      - web3_data
+                      - model
+                      - app_id
+                      - streamed
+                      - cancelled
+                      - provider_name
+                      - latency
+                      - moderation_latency
+                      - generation_time
+                      - finish_reason
+                      - tokens_prompt
+                      - tokens_completion
+                      - native_tokens_prompt
+                      - native_tokens_completion
+                      - native_tokens_completion_images
+                      - native_tokens_reasoning
+                      - native_tokens_cached
+                      - num_media_prompt
+                      - num_input_audio_prompt
+                      - num_media_completion
+                      - num_search_results
+                      - origin
+                      - usage
+                      - is_byok
+                      - native_finish_reason
+                      - external_user
+                      - api_type
+                      - router
+                      - provider_responses
+                      - user_agent
+                      - http_referer
+                    description: Generation data
                 required:
                   - data
-        '400':
-          description: Bad Request - Invalid credit amount or request body
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
+                description: Generation response
         '401':
           description: Unauthorized - Authentication required or invalid credentials
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/UnauthorizedResponse'
+        '402':
+          description: Payment Required - Insufficient credits or quota to complete request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentRequiredResponse'
+        '404':
+          description: Not Found - Generation not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
         '429':
           description: Too Many Requests - Rate limit exceeded
           content:
@@ -9942,6 +15353,3924 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalServerResponse'
+        '502':
+          description: Bad Gateway - Provider/upstream API failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadGatewayResponse'
+        '524':
+          description: Infrastructure Timeout - Request timed out at our edge network
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeNetworkTimeoutResponse'
+        '529':
+          description: Provider Overloaded - Provider is temporarily overloaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProviderOverloadedResponse'
+      operationId: getGeneration
+  /models/count:
+    get:
+      tags:
+        - Models
+      x-speakeasy-name-override: count
+      summary: Get total count of available models
+      parameters:
+        - schema:
+            type: string
+            description: >-
+              Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio,
+              embeddings) or "all" to include all models. Defaults to "text".
+            example: text
+          required: false
+          description: >-
+            Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio,
+            embeddings) or "all" to include all models. Defaults to "text".
+          name: output_modalities
+          in: query
+      responses:
+        '200':
+          description: Returns the total count of available models
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelsCountResponse'
+        '400':
+          description: Bad Request - Invalid output_modalities value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+      operationId: listModelsCount
+  /models:
+    get:
+      tags:
+        - Models
+      x-speakeasy-name-override: list
+      summary: List all models and their properties
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - programming
+              - roleplay
+              - marketing
+              - marketing/seo
+              - technology
+              - science
+              - translation
+              - legal
+              - finance
+              - health
+              - trivia
+              - academia
+            description: Filter models by use case category
+            example: programming
+          required: false
+          description: Filter models by use case category
+          name: category
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: supported_parameters
+          in: query
+        - schema:
+            type: string
+            description: >-
+              Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio,
+              embeddings) or "all" to include all models. Defaults to "text".
+            example: text
+          required: false
+          description: >-
+            Filter models by output modality. Accepts a comma-separated list of modalities (text, image, audio,
+            embeddings) or "all" to include all models. Defaults to "text".
+          name: output_modalities
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: use_rss
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: use_rss_chat_links
+          in: query
+      responses:
+        '200':
+          description: Returns a list of models or RSS feed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelsListResponse'
+            application/rss+xml:
+              schema:
+                type: string
+        '400':
+          description: Bad Request - Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+      operationId: getModels
+  /models/user:
+    get:
+      tags:
+        - Models
+      x-speakeasy-name-override: listForUser
+      description: >-
+        List models filtered by user provider preferences, [privacy
+        settings](https://openrouter.ai/docs/guides/privacy/logging), and
+        [guardrails](https://openrouter.ai/docs/guides/features/guardrails). If requesting through
+        `eu.openrouter.ai/api/v1/...` the results will be filtered to models that satisfy [EU in-region
+        routing](https://openrouter.ai/docs/guides/privacy/logging#enterprise-eu-in-region-routing).
+      summary: List models filtered by user provider preferences, privacy settings, and guardrails
+      security:
+        - bearer: []
+      responses:
+        '200':
+          description: Returns a list of models filtered by user provider preferences
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelsListResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Not Found - No eligible endpoints found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+      operationId: listModelsUser
+  /models/{author}/{slug}/endpoints:
+    get:
+      tags:
+        - Endpoints
+      operationId: listEndpoints
+      x-speakeasy-name-override: list
+      summary: List all endpoints for a model
+      parameters:
+        - schema:
+            type: string
+          required: true
+          name: author
+          in: path
+        - schema:
+            type: string
+          required: true
+          name: slug
+          in: path
+      responses:
+        '200':
+          description: Returns a list of endpoints
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ListEndpointsResponse'
+                required:
+                  - data
+        '404':
+          description: Not Found - Model does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error - Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /endpoints/zdr:
+    get:
+      tags:
+        - Endpoints
+      x-speakeasy-name-override: listZdrEndpoints
+      summary: Preview the impact of ZDR on the available endpoints
+      responses:
+        '200':
+          description: Returns a list of endpoints
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PublicEndpoint'
+                required:
+                  - data
+        '500':
+          description: Internal Server Error - Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+      operationId: listEndpointsZdr
+  /providers:
+    get:
+      tags:
+        - Providers
+      x-speakeasy-name-override: list
+      summary: List all providers
+      operationId: listProviders
+      responses:
+        '200':
+          description: Returns a list of providers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: Display name of the provider
+                          example: OpenAI
+                        slug:
+                          type: string
+                          description: URL-friendly identifier for the provider
+                          example: openai
+                        privacy_policy_url:
+                          type: string
+                          nullable: true
+                          description: URL to the provider's privacy policy
+                          example: https://openai.com/privacy
+                        terms_of_service_url:
+                          type: string
+                          nullable: true
+                          description: URL to the provider's terms of service
+                          example: https://openai.com/terms
+                        status_page_url:
+                          type: string
+                          nullable: true
+                          description: URL to the provider's status page
+                          example: https://status.openai.com
+                        headquarters:
+                          type: string
+                          nullable: true
+                          enum:
+                            - AD
+                            - AE
+                            - AF
+                            - AG
+                            - AI
+                            - AL
+                            - AM
+                            - AO
+                            - AQ
+                            - AR
+                            - AS
+                            - AT
+                            - AU
+                            - AW
+                            - AX
+                            - AZ
+                            - BA
+                            - BB
+                            - BD
+                            - BE
+                            - BF
+                            - BG
+                            - BH
+                            - BI
+                            - BJ
+                            - BL
+                            - BM
+                            - BN
+                            - BO
+                            - BQ
+                            - BR
+                            - BS
+                            - BT
+                            - BV
+                            - BW
+                            - BY
+                            - BZ
+                            - CA
+                            - CC
+                            - CD
+                            - CF
+                            - CG
+                            - CH
+                            - CI
+                            - CK
+                            - CL
+                            - CM
+                            - CN
+                            - CO
+                            - CR
+                            - CU
+                            - CV
+                            - CW
+                            - CX
+                            - CY
+                            - CZ
+                            - DE
+                            - DJ
+                            - DK
+                            - DM
+                            - DO
+                            - DZ
+                            - EC
+                            - EE
+                            - EG
+                            - EH
+                            - ER
+                            - ES
+                            - ET
+                            - FI
+                            - FJ
+                            - FK
+                            - FM
+                            - FO
+                            - FR
+                            - GA
+                            - GB
+                            - GD
+                            - GE
+                            - GF
+                            - GG
+                            - GH
+                            - GI
+                            - GL
+                            - GM
+                            - GN
+                            - GP
+                            - GQ
+                            - GR
+                            - GS
+                            - GT
+                            - GU
+                            - GW
+                            - GY
+                            - HK
+                            - HM
+                            - HN
+                            - HR
+                            - HT
+                            - HU
+                            - ID
+                            - IE
+                            - IL
+                            - IM
+                            - IN
+                            - IO
+                            - IQ
+                            - IR
+                            - IS
+                            - IT
+                            - JE
+                            - JM
+                            - JO
+                            - JP
+                            - KE
+                            - KG
+                            - KH
+                            - KI
+                            - KM
+                            - KN
+                            - KP
+                            - KR
+                            - KW
+                            - KY
+                            - KZ
+                            - LA
+                            - LB
+                            - LC
+                            - LI
+                            - LK
+                            - LR
+                            - LS
+                            - LT
+                            - LU
+                            - LV
+                            - LY
+                            - MA
+                            - MC
+                            - MD
+                            - ME
+                            - MF
+                            - MG
+                            - MH
+                            - MK
+                            - ML
+                            - MM
+                            - MN
+                            - MO
+                            - MP
+                            - MQ
+                            - MR
+                            - MS
+                            - MT
+                            - MU
+                            - MV
+                            - MW
+                            - MX
+                            - MY
+                            - MZ
+                            - NA
+                            - NC
+                            - NE
+                            - NF
+                            - NG
+                            - NI
+                            - NL
+                            - 'NO'
+                            - NP
+                            - NR
+                            - NU
+                            - NZ
+                            - OM
+                            - PA
+                            - PE
+                            - PF
+                            - PG
+                            - PH
+                            - PK
+                            - PL
+                            - PM
+                            - PN
+                            - PR
+                            - PS
+                            - PT
+                            - PW
+                            - PY
+                            - QA
+                            - RE
+                            - RO
+                            - RS
+                            - RU
+                            - RW
+                            - SA
+                            - SB
+                            - SC
+                            - SD
+                            - SE
+                            - SG
+                            - SH
+                            - SI
+                            - SJ
+                            - SK
+                            - SL
+                            - SM
+                            - SN
+                            - SO
+                            - SR
+                            - SS
+                            - ST
+                            - SV
+                            - SX
+                            - SY
+                            - SZ
+                            - TC
+                            - TD
+                            - TF
+                            - TG
+                            - TH
+                            - TJ
+                            - TK
+                            - TL
+                            - TM
+                            - TN
+                            - TO
+                            - TR
+                            - TT
+                            - TV
+                            - TW
+                            - TZ
+                            - UA
+                            - UG
+                            - UM
+                            - US
+                            - UY
+                            - UZ
+                            - VA
+                            - VC
+                            - VE
+                            - VG
+                            - VI
+                            - VN
+                            - VU
+                            - WF
+                            - WS
+                            - YE
+                            - YT
+                            - ZA
+                            - ZM
+                            - ZW
+                          description: ISO 3166-1 Alpha-2 country code of the provider headquarters
+                          example: US
+                        datacenters:
+                          type: array
+                          nullable: true
+                          items:
+                            type: string
+                            enum:
+                              - AD
+                              - AE
+                              - AF
+                              - AG
+                              - AI
+                              - AL
+                              - AM
+                              - AO
+                              - AQ
+                              - AR
+                              - AS
+                              - AT
+                              - AU
+                              - AW
+                              - AX
+                              - AZ
+                              - BA
+                              - BB
+                              - BD
+                              - BE
+                              - BF
+                              - BG
+                              - BH
+                              - BI
+                              - BJ
+                              - BL
+                              - BM
+                              - BN
+                              - BO
+                              - BQ
+                              - BR
+                              - BS
+                              - BT
+                              - BV
+                              - BW
+                              - BY
+                              - BZ
+                              - CA
+                              - CC
+                              - CD
+                              - CF
+                              - CG
+                              - CH
+                              - CI
+                              - CK
+                              - CL
+                              - CM
+                              - CN
+                              - CO
+                              - CR
+                              - CU
+                              - CV
+                              - CW
+                              - CX
+                              - CY
+                              - CZ
+                              - DE
+                              - DJ
+                              - DK
+                              - DM
+                              - DO
+                              - DZ
+                              - EC
+                              - EE
+                              - EG
+                              - EH
+                              - ER
+                              - ES
+                              - ET
+                              - FI
+                              - FJ
+                              - FK
+                              - FM
+                              - FO
+                              - FR
+                              - GA
+                              - GB
+                              - GD
+                              - GE
+                              - GF
+                              - GG
+                              - GH
+                              - GI
+                              - GL
+                              - GM
+                              - GN
+                              - GP
+                              - GQ
+                              - GR
+                              - GS
+                              - GT
+                              - GU
+                              - GW
+                              - GY
+                              - HK
+                              - HM
+                              - HN
+                              - HR
+                              - HT
+                              - HU
+                              - ID
+                              - IE
+                              - IL
+                              - IM
+                              - IN
+                              - IO
+                              - IQ
+                              - IR
+                              - IS
+                              - IT
+                              - JE
+                              - JM
+                              - JO
+                              - JP
+                              - KE
+                              - KG
+                              - KH
+                              - KI
+                              - KM
+                              - KN
+                              - KP
+                              - KR
+                              - KW
+                              - KY
+                              - KZ
+                              - LA
+                              - LB
+                              - LC
+                              - LI
+                              - LK
+                              - LR
+                              - LS
+                              - LT
+                              - LU
+                              - LV
+                              - LY
+                              - MA
+                              - MC
+                              - MD
+                              - ME
+                              - MF
+                              - MG
+                              - MH
+                              - MK
+                              - ML
+                              - MM
+                              - MN
+                              - MO
+                              - MP
+                              - MQ
+                              - MR
+                              - MS
+                              - MT
+                              - MU
+                              - MV
+                              - MW
+                              - MX
+                              - MY
+                              - MZ
+                              - NA
+                              - NC
+                              - NE
+                              - NF
+                              - NG
+                              - NI
+                              - NL
+                              - 'NO'
+                              - NP
+                              - NR
+                              - NU
+                              - NZ
+                              - OM
+                              - PA
+                              - PE
+                              - PF
+                              - PG
+                              - PH
+                              - PK
+                              - PL
+                              - PM
+                              - PN
+                              - PR
+                              - PS
+                              - PT
+                              - PW
+                              - PY
+                              - QA
+                              - RE
+                              - RO
+                              - RS
+                              - RU
+                              - RW
+                              - SA
+                              - SB
+                              - SC
+                              - SD
+                              - SE
+                              - SG
+                              - SH
+                              - SI
+                              - SJ
+                              - SK
+                              - SL
+                              - SM
+                              - SN
+                              - SO
+                              - SR
+                              - SS
+                              - ST
+                              - SV
+                              - SX
+                              - SY
+                              - SZ
+                              - TC
+                              - TD
+                              - TF
+                              - TG
+                              - TH
+                              - TJ
+                              - TK
+                              - TL
+                              - TM
+                              - TN
+                              - TO
+                              - TR
+                              - TT
+                              - TV
+                              - TW
+                              - TZ
+                              - UA
+                              - UG
+                              - UM
+                              - US
+                              - UY
+                              - UZ
+                              - VA
+                              - VC
+                              - VE
+                              - VG
+                              - VI
+                              - VN
+                              - VU
+                              - WF
+                              - WS
+                              - YE
+                              - YT
+                              - ZA
+                              - ZM
+                              - ZW
+                          description: ISO 3166-1 Alpha-2 country codes of the provider datacenter locations
+                          example:
+                            - US
+                            - IE
+                      required:
+                        - name
+                        - slug
+                        - privacy_policy_url
+                      example:
+                        name: OpenAI
+                        slug: openai
+                        privacy_policy_url: https://openai.com/privacy
+                        terms_of_service_url: https://openai.com/terms
+                        status_page_url: https://status.openai.com
+                        headquarters: US
+                        datacenters:
+                          - US
+                          - IE
+                required:
+                  - data
+        '500':
+          description: Internal Server Error - Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /keys:
+    get:
+      operationId: list
+      x-speakeasy-name-override: list
+      tags:
+        - API Keys
+      summary: List API keys
+      description: >-
+        List all API keys for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys)
+        required.
+      parameters:
+        - schema:
+            type: string
+            description: Whether to include disabled API keys in the response
+            example: 'false'
+          required: false
+          description: Whether to include disabled API keys in the response
+          name: include_disabled
+          in: query
+        - schema:
+            type: string
+            description: Number of API keys to skip for pagination
+            example: '0'
+          required: false
+          description: Number of API keys to skip for pagination
+          name: offset
+          in: query
+      responses:
+        '200':
+          description: List of API keys
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        hash:
+                          type: string
+                          description: Unique hash identifier for the API key
+                          example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                        name:
+                          type: string
+                          description: Name of the API key
+                          example: My Production Key
+                        label:
+                          type: string
+                          description: Human-readable label for the API key
+                          example: sk-or-v1-0e6...1c96
+                        disabled:
+                          type: boolean
+                          description: Whether the API key is disabled
+                          example: false
+                        limit:
+                          type: number
+                          format: double
+                          description: Spending limit for the API key in USD
+                          example: 100
+                        limit_remaining:
+                          type: number
+                          format: double
+                          description: Remaining spending limit in USD
+                          example: 74.5
+                        limit_reset:
+                          type: string
+                          nullable: true
+                          description: Type of limit reset for the API key
+                          example: monthly
+                        include_byok_in_limit:
+                          type: boolean
+                          description: Whether to include external BYOK usage in the credit limit
+                          example: false
+                        usage:
+                          type: number
+                          format: double
+                          description: Total OpenRouter credit usage (in USD) for the API key
+                          example: 25.5
+                        usage_daily:
+                          type: number
+                          format: double
+                          description: OpenRouter credit usage (in USD) for the current UTC day
+                          example: 25.5
+                        usage_weekly:
+                          type: number
+                          format: double
+                          description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
+                          example: 25.5
+                        usage_monthly:
+                          type: number
+                          format: double
+                          description: OpenRouter credit usage (in USD) for the current UTC month
+                          example: 25.5
+                        byok_usage:
+                          type: number
+                          format: double
+                          description: Total external BYOK usage (in USD) for the API key
+                          example: 17.38
+                        byok_usage_daily:
+                          type: number
+                          format: double
+                          description: External BYOK usage (in USD) for the current UTC day
+                          example: 17.38
+                        byok_usage_weekly:
+                          type: number
+                          format: double
+                          description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
+                          example: 17.38
+                        byok_usage_monthly:
+                          type: number
+                          format: double
+                          description: External BYOK usage (in USD) for current UTC month
+                          example: 17.38
+                        created_at:
+                          type: string
+                          description: ISO 8601 timestamp of when the API key was created
+                          example: '2025-08-24T10:30:00Z'
+                        updated_at:
+                          type: string
+                          nullable: true
+                          description: ISO 8601 timestamp of when the API key was last updated
+                          example: '2025-08-24T15:45:00Z'
+                        expires_at:
+                          type: string
+                          nullable: true
+                          format: date-time
+                          description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
+                          example: '2027-12-31T23:59:59Z'
+                        creator_user_id:
+                          type: string
+                          nullable: true
+                          description: >-
+                            The user ID of the key creator. For organization-owned keys, this is the member who created
+                            the key. For individual users, this is the user's own ID.
+                          example: user_2dHFtVWx2n56w6HkM0000000000
+                      required:
+                        - hash
+                        - name
+                        - label
+                        - disabled
+                        - limit
+                        - limit_remaining
+                        - limit_reset
+                        - include_byok_in_limit
+                        - usage
+                        - usage_daily
+                        - usage_weekly
+                        - usage_monthly
+                        - byok_usage
+                        - byok_usage_daily
+                        - byok_usage_weekly
+                        - byok_usage_monthly
+                        - created_at
+                        - updated_at
+                        - creator_user_id
+                      example:
+                        hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                        name: My Production Key
+                        label: sk-or-v1-0e6...1c96
+                        disabled: false
+                        limit: 100
+                        limit_remaining: 74.5
+                        limit_reset: monthly
+                        include_byok_in_limit: false
+                        usage: 25.5
+                        usage_daily: 25.5
+                        usage_weekly: 25.5
+                        usage_monthly: 25.5
+                        byok_usage: 17.38
+                        byok_usage_daily: 17.38
+                        byok_usage_weekly: 17.38
+                        byok_usage_monthly: 17.38
+                        created_at: '2025-08-24T10:30:00Z'
+                        updated_at: '2025-08-24T15:45:00Z'
+                        expires_at: '2027-12-31T23:59:59Z'
+                        creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+                    description: List of API keys
+                required:
+                  - data
+                example:
+                  data:
+                    - hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                      name: My Production Key
+                      label: Production API Key
+                      disabled: false
+                      limit: 100
+                      limit_remaining: 74.5
+                      limit_reset: monthly
+                      include_byok_in_limit: false
+                      usage: 25.5
+                      usage_daily: 25.5
+                      usage_weekly: 25.5
+                      usage_monthly: 25.5
+                      byok_usage: 17.38
+                      byok_usage_daily: 17.38
+                      byok_usage_weekly: 17.38
+                      byok_usage_monthly: 17.38
+                      created_at: '2025-08-24T10:30:00Z'
+                      updated_at: '2025-08-24T15:45:00Z'
+                      expires_at: '2027-12-31T23:59:59Z'
+                      creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '429':
+          description: Too Many Requests - Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TooManyRequestsResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+    post:
+      x-speakeasy-name-override: create
+      tags:
+        - API Keys
+      summary: Create a new API key
+      description: >-
+        Create a new API key for the authenticated user. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  description: Name for the new API key
+                  example: My New API Key
+                limit:
+                  type: number
+                  format: double
+                  description: Optional spending limit for the API key in USD
+                  example: 50
+                limit_reset:
+                  type: string
+                  nullable: true
+                  enum:
+                    - daily
+                    - weekly
+                    - monthly
+                  description: >-
+                    Type of limit reset for the API key (daily, weekly, monthly, or null for no reset). Resets happen
+                    automatically at midnight UTC, and weeks are Monday through Sunday.
+                  example: monthly
+                include_byok_in_limit:
+                  type: boolean
+                  description: Whether to include BYOK usage in the limit
+                  example: true
+                expires_at:
+                  type: string
+                  nullable: true
+                  format: date-time
+                  description: >-
+                    Optional ISO 8601 UTC timestamp when the API key should expire. Must be UTC, other timezones will be
+                    rejected
+                  example: '2027-12-31T23:59:59Z'
+                creator_user_id:
+                  type: string
+                  nullable: true
+                  minLength: 1
+                  description: >-
+                    Optional user ID of the key creator. Only meaningful for organization-owned keys where a specific
+                    member is creating the key.
+                  example: user_2dHFtVWx2n56w6HkM0000000000
+              required:
+                - name
+              example:
+                name: My New API Key
+                limit: 50
+                limit_reset: monthly
+                include_byok_in_limit: true
+                expires_at: '2027-12-31T23:59:59Z'
+        required: true
+      responses:
+        '201':
+          description: API key created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      hash:
+                        type: string
+                        description: Unique hash identifier for the API key
+                        example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                      name:
+                        type: string
+                        description: Name of the API key
+                        example: My Production Key
+                      label:
+                        type: string
+                        description: Human-readable label for the API key
+                        example: sk-or-v1-0e6...1c96
+                      disabled:
+                        type: boolean
+                        description: Whether the API key is disabled
+                        example: false
+                      limit:
+                        type: number
+                        format: double
+                        description: Spending limit for the API key in USD
+                        example: 100
+                      limit_remaining:
+                        type: number
+                        format: double
+                        description: Remaining spending limit in USD
+                        example: 74.5
+                      limit_reset:
+                        type: string
+                        nullable: true
+                        description: Type of limit reset for the API key
+                        example: monthly
+                      include_byok_in_limit:
+                        type: boolean
+                        description: Whether to include external BYOK usage in the credit limit
+                        example: false
+                      usage:
+                        type: number
+                        format: double
+                        description: Total OpenRouter credit usage (in USD) for the API key
+                        example: 25.5
+                      usage_daily:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC day
+                        example: 25.5
+                      usage_weekly:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
+                        example: 25.5
+                      usage_monthly:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC month
+                        example: 25.5
+                      byok_usage:
+                        type: number
+                        format: double
+                        description: Total external BYOK usage (in USD) for the API key
+                        example: 17.38
+                      byok_usage_daily:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for the current UTC day
+                        example: 17.38
+                      byok_usage_weekly:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
+                        example: 17.38
+                      byok_usage_monthly:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for current UTC month
+                        example: 17.38
+                      created_at:
+                        type: string
+                        description: ISO 8601 timestamp of when the API key was created
+                        example: '2025-08-24T10:30:00Z'
+                      updated_at:
+                        type: string
+                        nullable: true
+                        description: ISO 8601 timestamp of when the API key was last updated
+                        example: '2025-08-24T15:45:00Z'
+                      expires_at:
+                        type: string
+                        nullable: true
+                        format: date-time
+                        description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
+                        example: '2027-12-31T23:59:59Z'
+                      creator_user_id:
+                        type: string
+                        nullable: true
+                        description: >-
+                          The user ID of the key creator. For organization-owned keys, this is the member who created
+                          the key. For individual users, this is the user's own ID.
+                        example: user_2dHFtVWx2n56w6HkM0000000000
+                    required:
+                      - hash
+                      - name
+                      - label
+                      - disabled
+                      - limit
+                      - limit_remaining
+                      - limit_reset
+                      - include_byok_in_limit
+                      - usage
+                      - usage_daily
+                      - usage_weekly
+                      - usage_monthly
+                      - byok_usage
+                      - byok_usage_daily
+                      - byok_usage_weekly
+                      - byok_usage_monthly
+                      - created_at
+                      - updated_at
+                      - creator_user_id
+                    example:
+                      hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                      name: My Production Key
+                      label: sk-or-v1-0e6...1c96
+                      disabled: false
+                      limit: 100
+                      limit_remaining: 74.5
+                      limit_reset: monthly
+                      include_byok_in_limit: false
+                      usage: 25.5
+                      usage_daily: 25.5
+                      usage_weekly: 25.5
+                      usage_monthly: 25.5
+                      byok_usage: 17.38
+                      byok_usage_daily: 17.38
+                      byok_usage_weekly: 17.38
+                      byok_usage_monthly: 17.38
+                      created_at: '2025-08-24T10:30:00Z'
+                      updated_at: '2025-08-24T15:45:00Z'
+                      expires_at: '2027-12-31T23:59:59Z'
+                      creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+                    description: The created API key information
+                  key:
+                    type: string
+                    description: The actual API key string (only shown once)
+                    example: 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
+                required:
+                  - data
+                  - key
+                example:
+                  data:
+                    hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                    name: My New API Key
+                    label: My New API Key
+                    disabled: false
+                    limit: 50
+                    limit_remaining: 50
+                    limit_reset: monthly
+                    include_byok_in_limit: true
+                    usage: 0
+                    usage_daily: 0
+                    usage_weekly: 0
+                    usage_monthly: 0
+                    byok_usage: 0
+                    byok_usage_daily: 0
+                    byok_usage_weekly: 0
+                    byok_usage_monthly: 0
+                    created_at: '2025-08-24T10:30:00Z'
+                    updated_at: null
+                    expires_at: '2027-12-31T23:59:59Z'
+                    creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+                  key: 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
+        '400':
+          description: Bad Request - Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '429':
+          description: Too Many Requests - Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TooManyRequestsResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+      operationId: createKeys
+  /keys/{hash}:
+    patch:
+      x-speakeasy-name-override: update
+      tags:
+        - API Keys
+      summary: Update an API key
+      description: Update an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            description: The hash identifier of the API key to update
+            example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+          required: true
+          description: The hash identifier of the API key to update
+          name: hash
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: New name for the API key
+                  example: Updated API Key Name
+                disabled:
+                  type: boolean
+                  description: Whether to disable the API key
+                  example: false
+                limit:
+                  type: number
+                  format: double
+                  description: New spending limit for the API key in USD
+                  example: 75
+                limit_reset:
+                  type: string
+                  nullable: true
+                  enum:
+                    - daily
+                    - weekly
+                    - monthly
+                  description: >-
+                    New limit reset type for the API key (daily, weekly, monthly, or null for no reset). Resets happen
+                    automatically at midnight UTC, and weeks are Monday through Sunday.
+                  example: daily
+                include_byok_in_limit:
+                  type: boolean
+                  description: Whether to include BYOK usage in the limit
+                  example: true
+              example:
+                name: Updated API Key Name
+                disabled: false
+                limit: 75
+                limit_reset: daily
+                include_byok_in_limit: true
+        required: true
+      responses:
+        '200':
+          description: API key updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      hash:
+                        type: string
+                        description: Unique hash identifier for the API key
+                        example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                      name:
+                        type: string
+                        description: Name of the API key
+                        example: My Production Key
+                      label:
+                        type: string
+                        description: Human-readable label for the API key
+                        example: sk-or-v1-0e6...1c96
+                      disabled:
+                        type: boolean
+                        description: Whether the API key is disabled
+                        example: false
+                      limit:
+                        type: number
+                        format: double
+                        description: Spending limit for the API key in USD
+                        example: 100
+                      limit_remaining:
+                        type: number
+                        format: double
+                        description: Remaining spending limit in USD
+                        example: 74.5
+                      limit_reset:
+                        type: string
+                        nullable: true
+                        description: Type of limit reset for the API key
+                        example: monthly
+                      include_byok_in_limit:
+                        type: boolean
+                        description: Whether to include external BYOK usage in the credit limit
+                        example: false
+                      usage:
+                        type: number
+                        format: double
+                        description: Total OpenRouter credit usage (in USD) for the API key
+                        example: 25.5
+                      usage_daily:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC day
+                        example: 25.5
+                      usage_weekly:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
+                        example: 25.5
+                      usage_monthly:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC month
+                        example: 25.5
+                      byok_usage:
+                        type: number
+                        format: double
+                        description: Total external BYOK usage (in USD) for the API key
+                        example: 17.38
+                      byok_usage_daily:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for the current UTC day
+                        example: 17.38
+                      byok_usage_weekly:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
+                        example: 17.38
+                      byok_usage_monthly:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for current UTC month
+                        example: 17.38
+                      created_at:
+                        type: string
+                        description: ISO 8601 timestamp of when the API key was created
+                        example: '2025-08-24T10:30:00Z'
+                      updated_at:
+                        type: string
+                        nullable: true
+                        description: ISO 8601 timestamp of when the API key was last updated
+                        example: '2025-08-24T15:45:00Z'
+                      expires_at:
+                        type: string
+                        nullable: true
+                        format: date-time
+                        description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
+                        example: '2027-12-31T23:59:59Z'
+                      creator_user_id:
+                        type: string
+                        nullable: true
+                        description: >-
+                          The user ID of the key creator. For organization-owned keys, this is the member who created
+                          the key. For individual users, this is the user's own ID.
+                        example: user_2dHFtVWx2n56w6HkM0000000000
+                    required:
+                      - hash
+                      - name
+                      - label
+                      - disabled
+                      - limit
+                      - limit_remaining
+                      - limit_reset
+                      - include_byok_in_limit
+                      - usage
+                      - usage_daily
+                      - usage_weekly
+                      - usage_monthly
+                      - byok_usage
+                      - byok_usage_daily
+                      - byok_usage_weekly
+                      - byok_usage_monthly
+                      - created_at
+                      - updated_at
+                      - creator_user_id
+                    example:
+                      hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                      name: My Production Key
+                      label: sk-or-v1-0e6...1c96
+                      disabled: false
+                      limit: 100
+                      limit_remaining: 74.5
+                      limit_reset: monthly
+                      include_byok_in_limit: false
+                      usage: 25.5
+                      usage_daily: 25.5
+                      usage_weekly: 25.5
+                      usage_monthly: 25.5
+                      byok_usage: 17.38
+                      byok_usage_daily: 17.38
+                      byok_usage_weekly: 17.38
+                      byok_usage_monthly: 17.38
+                      created_at: '2025-08-24T10:30:00Z'
+                      updated_at: '2025-08-24T15:45:00Z'
+                      expires_at: '2027-12-31T23:59:59Z'
+                      creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+                    description: The updated API key information
+                required:
+                  - data
+                example:
+                  data:
+                    hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                    name: Updated API Key Name
+                    label: Updated API Key Name
+                    disabled: false
+                    limit: 75
+                    limit_remaining: 49.5
+                    limit_reset: daily
+                    include_byok_in_limit: true
+                    usage: 25.5
+                    usage_daily: 25.5
+                    usage_weekly: 25.5
+                    usage_monthly: 25.5
+                    byok_usage: 17.38
+                    byok_usage_daily: 17.38
+                    byok_usage_weekly: 17.38
+                    byok_usage_monthly: 17.38
+                    created_at: '2025-08-24T10:30:00Z'
+                    updated_at: '2025-08-24T16:00:00Z'
+                    expires_at: null
+                    creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+        '400':
+          description: Bad Request - Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Not Found - API key does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '429':
+          description: Too Many Requests - Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TooManyRequestsResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+      operationId: updateKeys
+    delete:
+      x-speakeasy-name-override: delete
+      tags:
+        - API Keys
+      summary: Delete an API key
+      description: Delete an existing API key. [Management key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            description: The hash identifier of the API key to delete
+            example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+          required: true
+          description: The hash identifier of the API key to delete
+          name: hash
+          in: path
+      responses:
+        '200':
+          description: API key deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+                    const: true
+                    description: Confirmation that the API key was deleted
+                    example: true
+                required:
+                  - deleted
+                example:
+                  deleted: true
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Not Found - API key does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '429':
+          description: Too Many Requests - Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TooManyRequestsResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+      operationId: deleteKeys
+    get:
+      operationId: getKey
+      x-speakeasy-name-override: get
+      tags:
+        - API Keys
+      summary: Get a single API key
+      description: Get a single API key by hash. [Management key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            description: The hash identifier of the API key to retrieve
+            example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+          required: true
+          description: The hash identifier of the API key to retrieve
+          name: hash
+          in: path
+      responses:
+        '200':
+          description: API key details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      hash:
+                        type: string
+                        description: Unique hash identifier for the API key
+                        example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                      name:
+                        type: string
+                        description: Name of the API key
+                        example: My Production Key
+                      label:
+                        type: string
+                        description: Human-readable label for the API key
+                        example: sk-or-v1-0e6...1c96
+                      disabled:
+                        type: boolean
+                        description: Whether the API key is disabled
+                        example: false
+                      limit:
+                        type: number
+                        format: double
+                        description: Spending limit for the API key in USD
+                        example: 100
+                      limit_remaining:
+                        type: number
+                        format: double
+                        description: Remaining spending limit in USD
+                        example: 74.5
+                      limit_reset:
+                        type: string
+                        nullable: true
+                        description: Type of limit reset for the API key
+                        example: monthly
+                      include_byok_in_limit:
+                        type: boolean
+                        description: Whether to include external BYOK usage in the credit limit
+                        example: false
+                      usage:
+                        type: number
+                        format: double
+                        description: Total OpenRouter credit usage (in USD) for the API key
+                        example: 25.5
+                      usage_daily:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC day
+                        example: 25.5
+                      usage_weekly:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
+                        example: 25.5
+                      usage_monthly:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC month
+                        example: 25.5
+                      byok_usage:
+                        type: number
+                        format: double
+                        description: Total external BYOK usage (in USD) for the API key
+                        example: 17.38
+                      byok_usage_daily:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for the current UTC day
+                        example: 17.38
+                      byok_usage_weekly:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
+                        example: 17.38
+                      byok_usage_monthly:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for current UTC month
+                        example: 17.38
+                      created_at:
+                        type: string
+                        description: ISO 8601 timestamp of when the API key was created
+                        example: '2025-08-24T10:30:00Z'
+                      updated_at:
+                        type: string
+                        nullable: true
+                        description: ISO 8601 timestamp of when the API key was last updated
+                        example: '2025-08-24T15:45:00Z'
+                      expires_at:
+                        type: string
+                        nullable: true
+                        format: date-time
+                        description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
+                        example: '2027-12-31T23:59:59Z'
+                      creator_user_id:
+                        type: string
+                        nullable: true
+                        description: >-
+                          The user ID of the key creator. For organization-owned keys, this is the member who created
+                          the key. For individual users, this is the user's own ID.
+                        example: user_2dHFtVWx2n56w6HkM0000000000
+                    required:
+                      - hash
+                      - name
+                      - label
+                      - disabled
+                      - limit
+                      - limit_remaining
+                      - limit_reset
+                      - include_byok_in_limit
+                      - usage
+                      - usage_daily
+                      - usage_weekly
+                      - usage_monthly
+                      - byok_usage
+                      - byok_usage_daily
+                      - byok_usage_weekly
+                      - byok_usage_monthly
+                      - created_at
+                      - updated_at
+                      - creator_user_id
+                    example:
+                      hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                      name: My Production Key
+                      label: sk-or-v1-0e6...1c96
+                      disabled: false
+                      limit: 100
+                      limit_remaining: 74.5
+                      limit_reset: monthly
+                      include_byok_in_limit: false
+                      usage: 25.5
+                      usage_daily: 25.5
+                      usage_weekly: 25.5
+                      usage_monthly: 25.5
+                      byok_usage: 17.38
+                      byok_usage_daily: 17.38
+                      byok_usage_weekly: 17.38
+                      byok_usage_monthly: 17.38
+                      created_at: '2025-08-24T10:30:00Z'
+                      updated_at: '2025-08-24T15:45:00Z'
+                      expires_at: '2027-12-31T23:59:59Z'
+                      creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+                    description: The API key information
+                required:
+                  - data
+                example:
+                  data:
+                    hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
+                    name: My Production Key
+                    label: Production API Key
+                    disabled: false
+                    limit: 100
+                    limit_remaining: 74.5
+                    limit_reset: monthly
+                    include_byok_in_limit: false
+                    usage: 25.5
+                    usage_daily: 25.5
+                    usage_weekly: 25.5
+                    usage_monthly: 25.5
+                    byok_usage: 17.38
+                    byok_usage_daily: 17.38
+                    byok_usage_weekly: 17.38
+                    byok_usage_monthly: 17.38
+                    created_at: '2025-08-24T10:30:00Z'
+                    updated_at: '2025-08-24T15:45:00Z'
+                    expires_at: '2027-12-31T23:59:59Z'
+                    creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Not Found - API key does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '429':
+          description: Too Many Requests - Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TooManyRequestsResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /organization/members:
+    get:
+      operationId: listOrganizationMembers
+      x-speakeasy-name-override: listMembers
+      tags:
+        - Organization
+      summary: List organization members
+      description: >-
+        List all members of the organization associated with the authenticated management key. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            description: Number of records to skip for pagination
+            example: '0'
+          required: false
+          description: Number of records to skip for pagination
+          name: offset
+          in: query
+        - schema:
+            type: string
+            description: Maximum number of records to return (max 100)
+            example: '50'
+          required: false
+          description: Maximum number of records to return (max 100)
+          name: limit
+          in: query
+      responses:
+        '200':
+          description: List of organization members
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: User ID of the organization member
+                          example: user_2dHFtVWx2n56w6HkM0000000000
+                        first_name:
+                          type: string
+                          nullable: true
+                          description: First name of the member
+                          example: Jane
+                        last_name:
+                          type: string
+                          nullable: true
+                          description: Last name of the member
+                          example: Doe
+                        email:
+                          type: string
+                          description: Email address of the member
+                          example: jane.doe@example.com
+                        role:
+                          type: string
+                          enum:
+                            - org:admin
+                            - org:member
+                          description: Role of the member in the organization
+                          example: org:member
+                      required:
+                        - id
+                        - first_name
+                        - last_name
+                        - email
+                        - role
+                    description: List of organization members
+                  total_count:
+                    type: integer
+                    description: Total number of members in the organization
+                    example: 25
+                required:
+                  - data
+                  - total_count
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Not Found - Organization not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /guardrails:
+    get:
+      operationId: listGuardrails
+      x-speakeasy-name-override: list
+      tags:
+        - Guardrails
+      summary: List guardrails
+      description: >-
+        List all guardrails for the authenticated user. [Management key](/docs/guides/overview/auth/management-api-keys)
+        required.
+      parameters:
+        - schema:
+            type: string
+            description: Number of records to skip for pagination
+            example: '0'
+          required: false
+          description: Number of records to skip for pagination
+          name: offset
+          in: query
+        - schema:
+            type: string
+            description: Maximum number of records to return (max 100)
+            example: '50'
+          required: false
+          description: Maximum number of records to return (max 100)
+          name: limit
+          in: query
+      responses:
+        '200':
+          description: List of guardrails
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: Unique identifier for the guardrail
+                          example: 550e8400-e29b-41d4-a716-446655440000
+                        name:
+                          type: string
+                          description: Name of the guardrail
+                          example: Production Guardrail
+                        description:
+                          type: string
+                          nullable: true
+                          description: Description of the guardrail
+                          example: Guardrail for production environment
+                        limit_usd:
+                          type: number
+                          format: double
+                          description: Spending limit in USD
+                          example: 100
+                        reset_interval:
+                          type: string
+                          nullable: true
+                          enum:
+                            - daily
+                            - weekly
+                            - monthly
+                          description: Interval at which the limit resets (daily, weekly, monthly)
+                          example: monthly
+                        allowed_providers:
+                          type: array
+                          nullable: true
+                          items:
+                            type: string
+                          description: List of allowed provider IDs
+                          example:
+                            - openai
+                            - anthropic
+                            - google
+                        ignored_providers:
+                          type: array
+                          nullable: true
+                          items:
+                            type: string
+                          description: List of provider IDs to exclude from routing
+                          example:
+                            - azure
+                        allowed_models:
+                          type: array
+                          nullable: true
+                          items:
+                            type: string
+                          description: Array of model canonical_slugs (immutable identifiers)
+                          example:
+                            - openai/gpt-5.2-20251211
+                            - anthropic/claude-4.5-opus-20251124
+                            - deepseek/deepseek-r1-0528:free
+                        enforce_zdr:
+                          type: boolean
+                          nullable: true
+                          description: Whether to enforce zero data retention
+                          example: false
+                        created_at:
+                          type: string
+                          description: ISO 8601 timestamp of when the guardrail was created
+                          example: '2025-08-24T10:30:00Z'
+                        updated_at:
+                          type: string
+                          nullable: true
+                          description: ISO 8601 timestamp of when the guardrail was last updated
+                          example: '2025-08-24T15:45:00Z'
+                      required:
+                        - id
+                        - name
+                        - created_at
+                      example:
+                        id: 550e8400-e29b-41d4-a716-446655440000
+                        name: Production Guardrail
+                        description: Guardrail for production environment
+                        limit_usd: 100
+                        reset_interval: monthly
+                        allowed_providers:
+                          - openai
+                          - anthropic
+                          - google
+                        ignored_providers: null
+                        allowed_models: null
+                        enforce_zdr: false
+                        created_at: '2025-08-24T10:30:00Z'
+                        updated_at: '2025-08-24T15:45:00Z'
+                    description: List of guardrails
+                  total_count:
+                    type: integer
+                    description: Total number of guardrails
+                    example: 25
+                required:
+                  - data
+                  - total_count
+                example:
+                  data:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Production Guardrail
+                      description: Guardrail for production environment
+                      limit_usd: 100
+                      reset_interval: monthly
+                      allowed_providers:
+                        - openai
+                        - anthropic
+                        - google
+                      ignored_providers: null
+                      allowed_models: null
+                      enforce_zdr: false
+                      created_at: '2025-08-24T10:30:00Z'
+                      updated_at: '2025-08-24T15:45:00Z'
+                  total_count: 1
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+    post:
+      operationId: createGuardrail
+      x-speakeasy-name-override: create
+      tags:
+        - Guardrails
+      summary: Create a guardrail
+      description: >-
+        Create a new guardrail for the authenticated user. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 200
+                  description: Name for the new guardrail
+                  example: My New Guardrail
+                description:
+                  type: string
+                  nullable: true
+                  maxLength: 1000
+                  description: Description of the guardrail
+                  example: A guardrail for limiting API usage
+                limit_usd:
+                  type: number
+                  format: double
+                  description: Spending limit in USD
+                  example: 50
+                reset_interval:
+                  type: string
+                  nullable: true
+                  enum:
+                    - daily
+                    - weekly
+                    - monthly
+                  description: Interval at which the limit resets (daily, weekly, monthly)
+                  example: monthly
+                allowed_providers:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+                  minItems: 1
+                  description: List of allowed provider IDs
+                  example:
+                    - openai
+                    - anthropic
+                    - deepseek
+                ignored_providers:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+                  minItems: 1
+                  description: List of provider IDs to exclude from routing
+                  example:
+                    - azure
+                allowed_models:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+                  minItems: 1
+                  description: Array of model identifiers (slug or canonical_slug accepted)
+                  example:
+                    - openai/gpt-5.2
+                    - anthropic/claude-4.5-opus-20251124
+                    - deepseek/deepseek-r1-0528:free
+                enforce_zdr:
+                  type: boolean
+                  nullable: true
+                  description: Whether to enforce zero data retention
+                  example: false
+              required:
+                - name
+              example:
+                name: My New Guardrail
+                description: A guardrail for limiting API usage
+                limit_usd: 50
+                reset_interval: monthly
+                allowed_providers:
+                  - openai
+                  - anthropic
+                  - deepseek
+                ignored_providers: null
+                allowed_models: null
+                enforce_zdr: false
+        required: true
+      responses:
+        '201':
+          description: Guardrail created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        description: Unique identifier for the guardrail
+                        example: 550e8400-e29b-41d4-a716-446655440000
+                      name:
+                        type: string
+                        description: Name of the guardrail
+                        example: Production Guardrail
+                      description:
+                        type: string
+                        nullable: true
+                        description: Description of the guardrail
+                        example: Guardrail for production environment
+                      limit_usd:
+                        type: number
+                        format: double
+                        description: Spending limit in USD
+                        example: 100
+                      reset_interval:
+                        type: string
+                        nullable: true
+                        enum:
+                          - daily
+                          - weekly
+                          - monthly
+                        description: Interval at which the limit resets (daily, weekly, monthly)
+                        example: monthly
+                      allowed_providers:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: List of allowed provider IDs
+                        example:
+                          - openai
+                          - anthropic
+                          - google
+                      ignored_providers:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: List of provider IDs to exclude from routing
+                        example:
+                          - azure
+                      allowed_models:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: Array of model canonical_slugs (immutable identifiers)
+                        example:
+                          - openai/gpt-5.2-20251211
+                          - anthropic/claude-4.5-opus-20251124
+                          - deepseek/deepseek-r1-0528:free
+                      enforce_zdr:
+                        type: boolean
+                        nullable: true
+                        description: Whether to enforce zero data retention
+                        example: false
+                      created_at:
+                        type: string
+                        description: ISO 8601 timestamp of when the guardrail was created
+                        example: '2025-08-24T10:30:00Z'
+                      updated_at:
+                        type: string
+                        nullable: true
+                        description: ISO 8601 timestamp of when the guardrail was last updated
+                        example: '2025-08-24T15:45:00Z'
+                    required:
+                      - id
+                      - name
+                      - created_at
+                    example:
+                      id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Production Guardrail
+                      description: Guardrail for production environment
+                      limit_usd: 100
+                      reset_interval: monthly
+                      allowed_providers:
+                        - openai
+                        - anthropic
+                        - google
+                      ignored_providers: null
+                      allowed_models: null
+                      enforce_zdr: false
+                      created_at: '2025-08-24T10:30:00Z'
+                      updated_at: '2025-08-24T15:45:00Z'
+                    description: The created guardrail
+                required:
+                  - data
+                example:
+                  data:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: My New Guardrail
+                    description: A guardrail for limiting API usage
+                    limit_usd: 50
+                    reset_interval: monthly
+                    allowed_providers:
+                      - openai
+                      - anthropic
+                      - google
+                    ignored_providers: null
+                    allowed_models: null
+                    enforce_zdr: false
+                    created_at: '2025-08-24T10:30:00Z'
+                    updated_at: null
+        '400':
+          description: Bad Request - Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /guardrails/{id}:
+    get:
+      operationId: getGuardrail
+      x-speakeasy-name-override: get
+      tags:
+        - Guardrails
+      summary: Get a guardrail
+      description: Get a single guardrail by ID. [Management key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail to retrieve
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail to retrieve
+          name: id
+          in: path
+      responses:
+        '200':
+          description: Guardrail details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        description: Unique identifier for the guardrail
+                        example: 550e8400-e29b-41d4-a716-446655440000
+                      name:
+                        type: string
+                        description: Name of the guardrail
+                        example: Production Guardrail
+                      description:
+                        type: string
+                        nullable: true
+                        description: Description of the guardrail
+                        example: Guardrail for production environment
+                      limit_usd:
+                        type: number
+                        format: double
+                        description: Spending limit in USD
+                        example: 100
+                      reset_interval:
+                        type: string
+                        nullable: true
+                        enum:
+                          - daily
+                          - weekly
+                          - monthly
+                        description: Interval at which the limit resets (daily, weekly, monthly)
+                        example: monthly
+                      allowed_providers:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: List of allowed provider IDs
+                        example:
+                          - openai
+                          - anthropic
+                          - google
+                      ignored_providers:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: List of provider IDs to exclude from routing
+                        example:
+                          - azure
+                      allowed_models:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: Array of model canonical_slugs (immutable identifiers)
+                        example:
+                          - openai/gpt-5.2-20251211
+                          - anthropic/claude-4.5-opus-20251124
+                          - deepseek/deepseek-r1-0528:free
+                      enforce_zdr:
+                        type: boolean
+                        nullable: true
+                        description: Whether to enforce zero data retention
+                        example: false
+                      created_at:
+                        type: string
+                        description: ISO 8601 timestamp of when the guardrail was created
+                        example: '2025-08-24T10:30:00Z'
+                      updated_at:
+                        type: string
+                        nullable: true
+                        description: ISO 8601 timestamp of when the guardrail was last updated
+                        example: '2025-08-24T15:45:00Z'
+                    required:
+                      - id
+                      - name
+                      - created_at
+                    example:
+                      id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Production Guardrail
+                      description: Guardrail for production environment
+                      limit_usd: 100
+                      reset_interval: monthly
+                      allowed_providers:
+                        - openai
+                        - anthropic
+                        - google
+                      ignored_providers: null
+                      allowed_models: null
+                      enforce_zdr: false
+                      created_at: '2025-08-24T10:30:00Z'
+                      updated_at: '2025-08-24T15:45:00Z'
+                    description: The guardrail
+                required:
+                  - data
+                example:
+                  data:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Production Guardrail
+                    description: Guardrail for production environment
+                    limit_usd: 100
+                    reset_interval: monthly
+                    allowed_providers:
+                      - openai
+                      - anthropic
+                      - google
+                    ignored_providers: null
+                    allowed_models: null
+                    enforce_zdr: false
+                    created_at: '2025-08-24T10:30:00Z'
+                    updated_at: '2025-08-24T15:45:00Z'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Not Found - Guardrail does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+    patch:
+      operationId: updateGuardrail
+      x-speakeasy-name-override: update
+      tags:
+        - Guardrails
+      summary: Update a guardrail
+      description: Update an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail to update
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail to update
+          name: id
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 200
+                  description: New name for the guardrail
+                  example: Updated Guardrail Name
+                description:
+                  type: string
+                  nullable: true
+                  maxLength: 1000
+                  description: New description for the guardrail
+                  example: Updated description
+                limit_usd:
+                  type: number
+                  format: double
+                  description: New spending limit in USD
+                  example: 75
+                reset_interval:
+                  type: string
+                  nullable: true
+                  enum:
+                    - daily
+                    - weekly
+                    - monthly
+                  description: Interval at which the limit resets (daily, weekly, monthly)
+                  example: monthly
+                allowed_providers:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+                  minItems: 1
+                  description: New list of allowed provider IDs
+                  example:
+                    - openai
+                    - anthropic
+                    - deepseek
+                ignored_providers:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+                  minItems: 1
+                  description: List of provider IDs to exclude from routing
+                  example:
+                    - azure
+                allowed_models:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+                  minItems: 1
+                  description: Array of model identifiers (slug or canonical_slug accepted)
+                  example:
+                    - openai/gpt-5.2
+                enforce_zdr:
+                  type: boolean
+                  nullable: true
+                  description: Whether to enforce zero data retention
+                  example: true
+              example:
+                name: Updated Guardrail Name
+                description: Updated description
+                limit_usd: 75
+                reset_interval: weekly
+        required: true
+      responses:
+        '200':
+          description: Guardrail updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        description: Unique identifier for the guardrail
+                        example: 550e8400-e29b-41d4-a716-446655440000
+                      name:
+                        type: string
+                        description: Name of the guardrail
+                        example: Production Guardrail
+                      description:
+                        type: string
+                        nullable: true
+                        description: Description of the guardrail
+                        example: Guardrail for production environment
+                      limit_usd:
+                        type: number
+                        format: double
+                        description: Spending limit in USD
+                        example: 100
+                      reset_interval:
+                        type: string
+                        nullable: true
+                        enum:
+                          - daily
+                          - weekly
+                          - monthly
+                        description: Interval at which the limit resets (daily, weekly, monthly)
+                        example: monthly
+                      allowed_providers:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: List of allowed provider IDs
+                        example:
+                          - openai
+                          - anthropic
+                          - google
+                      ignored_providers:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: List of provider IDs to exclude from routing
+                        example:
+                          - azure
+                      allowed_models:
+                        type: array
+                        nullable: true
+                        items:
+                          type: string
+                        description: Array of model canonical_slugs (immutable identifiers)
+                        example:
+                          - openai/gpt-5.2-20251211
+                          - anthropic/claude-4.5-opus-20251124
+                          - deepseek/deepseek-r1-0528:free
+                      enforce_zdr:
+                        type: boolean
+                        nullable: true
+                        description: Whether to enforce zero data retention
+                        example: false
+                      created_at:
+                        type: string
+                        description: ISO 8601 timestamp of when the guardrail was created
+                        example: '2025-08-24T10:30:00Z'
+                      updated_at:
+                        type: string
+                        nullable: true
+                        description: ISO 8601 timestamp of when the guardrail was last updated
+                        example: '2025-08-24T15:45:00Z'
+                    required:
+                      - id
+                      - name
+                      - created_at
+                    example:
+                      id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Production Guardrail
+                      description: Guardrail for production environment
+                      limit_usd: 100
+                      reset_interval: monthly
+                      allowed_providers:
+                        - openai
+                        - anthropic
+                        - google
+                      ignored_providers: null
+                      allowed_models: null
+                      enforce_zdr: false
+                      created_at: '2025-08-24T10:30:00Z'
+                      updated_at: '2025-08-24T15:45:00Z'
+                    description: The updated guardrail
+                required:
+                  - data
+                example:
+                  data:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Updated Guardrail Name
+                    description: Updated description
+                    limit_usd: 75
+                    reset_interval: weekly
+                    allowed_providers:
+                      - openai
+                    ignored_providers: null
+                    allowed_models: null
+                    enforce_zdr: true
+                    created_at: '2025-08-24T10:30:00Z'
+                    updated_at: '2025-08-24T16:00:00Z'
+        '400':
+          description: Bad Request - Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Not Found - Guardrail does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+    delete:
+      operationId: deleteGuardrail
+      x-speakeasy-name-override: delete
+      tags:
+        - Guardrails
+      summary: Delete a guardrail
+      description: Delete an existing guardrail. [Management key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail to delete
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail to delete
+          name: id
+          in: path
+      responses:
+        '200':
+          description: Guardrail deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+                    const: true
+                    description: Confirmation that the guardrail was deleted
+                    example: true
+                required:
+                  - deleted
+                example:
+                  deleted: true
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Not Found - Guardrail does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /guardrails/assignments/keys:
+    get:
+      operationId: listKeyAssignments
+      x-speakeasy-name-override: listKeyAssignments
+      tags:
+        - Guardrails
+      summary: List all key assignments
+      description: >-
+        List all API key guardrail assignments for the authenticated user. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            description: Number of records to skip for pagination
+            example: '0'
+          required: false
+          description: Number of records to skip for pagination
+          name: offset
+          in: query
+        - schema:
+            type: string
+            description: Maximum number of records to return (max 100)
+            example: '50'
+          required: false
+          description: Maximum number of records to return (max 100)
+          name: limit
+          in: query
+      responses:
+        '200':
+          description: List of key assignments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: Unique identifier for the assignment
+                          example: 550e8400-e29b-41d4-a716-446655440000
+                        key_hash:
+                          type: string
+                          description: Hash of the assigned API key
+                          example: c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93
+                        guardrail_id:
+                          type: string
+                          format: uuid
+                          description: ID of the guardrail
+                          example: 550e8400-e29b-41d4-a716-446655440001
+                        key_name:
+                          type: string
+                          description: Name of the API key
+                          example: Production Key
+                        key_label:
+                          type: string
+                          description: Label of the API key
+                          example: prod-key
+                        assigned_by:
+                          type: string
+                          nullable: true
+                          description: User ID of who made the assignment
+                          example: user_abc123
+                        created_at:
+                          type: string
+                          description: ISO 8601 timestamp of when the assignment was created
+                          example: '2025-08-24T10:30:00Z'
+                      required:
+                        - id
+                        - key_hash
+                        - guardrail_id
+                        - key_name
+                        - key_label
+                        - assigned_by
+                        - created_at
+                    description: List of key assignments
+                  total_count:
+                    type: integer
+                    description: Total number of key assignments for this guardrail
+                    example: 25
+                required:
+                  - data
+                  - total_count
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /guardrails/assignments/members:
+    get:
+      operationId: listMemberAssignments
+      x-speakeasy-name-override: listMemberAssignments
+      tags:
+        - Guardrails
+      summary: List all member assignments
+      description: >-
+        List all organization member guardrail assignments for the authenticated user. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            description: Number of records to skip for pagination
+            example: '0'
+          required: false
+          description: Number of records to skip for pagination
+          name: offset
+          in: query
+        - schema:
+            type: string
+            description: Maximum number of records to return (max 100)
+            example: '50'
+          required: false
+          description: Maximum number of records to return (max 100)
+          name: limit
+          in: query
+      responses:
+        '200':
+          description: List of member assignments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: Unique identifier for the assignment
+                          example: 550e8400-e29b-41d4-a716-446655440000
+                        user_id:
+                          type: string
+                          description: Clerk user ID of the assigned member
+                          example: user_abc123
+                        organization_id:
+                          type: string
+                          description: Organization ID
+                          example: org_xyz789
+                        guardrail_id:
+                          type: string
+                          format: uuid
+                          description: ID of the guardrail
+                          example: 550e8400-e29b-41d4-a716-446655440001
+                        assigned_by:
+                          type: string
+                          nullable: true
+                          description: User ID of who made the assignment
+                          example: user_abc123
+                        created_at:
+                          type: string
+                          description: ISO 8601 timestamp of when the assignment was created
+                          example: '2025-08-24T10:30:00Z'
+                      required:
+                        - id
+                        - user_id
+                        - organization_id
+                        - guardrail_id
+                        - assigned_by
+                        - created_at
+                    description: List of member assignments
+                  total_count:
+                    type: integer
+                    description: Total number of member assignments
+                    example: 10
+                required:
+                  - data
+                  - total_count
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /guardrails/{id}/assignments/keys:
+    get:
+      operationId: listGuardrailKeyAssignments
+      x-speakeasy-name-override: listGuardrailKeyAssignments
+      tags:
+        - Guardrails
+      summary: List key assignments for a guardrail
+      description: >-
+        List all API key assignments for a specific guardrail. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail
+          name: id
+          in: path
+        - schema:
+            type: string
+            description: Number of records to skip for pagination
+            example: '0'
+          required: false
+          description: Number of records to skip for pagination
+          name: offset
+          in: query
+        - schema:
+            type: string
+            description: Maximum number of records to return (max 100)
+            example: '50'
+          required: false
+          description: Maximum number of records to return (max 100)
+          name: limit
+          in: query
+      responses:
+        '200':
+          description: List of key assignments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: Unique identifier for the assignment
+                          example: 550e8400-e29b-41d4-a716-446655440000
+                        key_hash:
+                          type: string
+                          description: Hash of the assigned API key
+                          example: c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93
+                        guardrail_id:
+                          type: string
+                          format: uuid
+                          description: ID of the guardrail
+                          example: 550e8400-e29b-41d4-a716-446655440001
+                        key_name:
+                          type: string
+                          description: Name of the API key
+                          example: Production Key
+                        key_label:
+                          type: string
+                          description: Label of the API key
+                          example: prod-key
+                        assigned_by:
+                          type: string
+                          nullable: true
+                          description: User ID of who made the assignment
+                          example: user_abc123
+                        created_at:
+                          type: string
+                          description: ISO 8601 timestamp of when the assignment was created
+                          example: '2025-08-24T10:30:00Z'
+                      required:
+                        - id
+                        - key_hash
+                        - guardrail_id
+                        - key_name
+                        - key_label
+                        - assigned_by
+                        - created_at
+                    description: List of key assignments
+                  total_count:
+                    type: integer
+                    description: Total number of key assignments for this guardrail
+                    example: 25
+                required:
+                  - data
+                  - total_count
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Guardrail not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+    post:
+      operationId: bulkAssignKeysToGuardrail
+      x-speakeasy-name-override: bulkAssignKeys
+      tags:
+        - Guardrails
+      summary: Bulk assign keys to a guardrail
+      description: >-
+        Assign multiple API keys to a specific guardrail. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail
+          name: id
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key_hashes:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                  minItems: 1
+                  description: Array of API key hashes to assign to the guardrail
+                  example:
+                    - c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93
+              required:
+                - key_hashes
+        required: true
+      responses:
+        '200':
+          description: Assignment result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  assigned_count:
+                    type: integer
+                    description: Number of keys successfully assigned
+                    example: 3
+                required:
+                  - assigned_count
+        '400':
+          description: Bad Request - Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Guardrail not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /guardrails/{id}/assignments/members:
+    get:
+      operationId: listGuardrailMemberAssignments
+      x-speakeasy-name-override: listGuardrailMemberAssignments
+      tags:
+        - Guardrails
+      summary: List member assignments for a guardrail
+      description: >-
+        List all organization member assignments for a specific guardrail. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail
+          name: id
+          in: path
+        - schema:
+            type: string
+            description: Number of records to skip for pagination
+            example: '0'
+          required: false
+          description: Number of records to skip for pagination
+          name: offset
+          in: query
+        - schema:
+            type: string
+            description: Maximum number of records to return (max 100)
+            example: '50'
+          required: false
+          description: Maximum number of records to return (max 100)
+          name: limit
+          in: query
+      responses:
+        '200':
+          description: List of member assignments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: Unique identifier for the assignment
+                          example: 550e8400-e29b-41d4-a716-446655440000
+                        user_id:
+                          type: string
+                          description: Clerk user ID of the assigned member
+                          example: user_abc123
+                        organization_id:
+                          type: string
+                          description: Organization ID
+                          example: org_xyz789
+                        guardrail_id:
+                          type: string
+                          format: uuid
+                          description: ID of the guardrail
+                          example: 550e8400-e29b-41d4-a716-446655440001
+                        assigned_by:
+                          type: string
+                          nullable: true
+                          description: User ID of who made the assignment
+                          example: user_abc123
+                        created_at:
+                          type: string
+                          description: ISO 8601 timestamp of when the assignment was created
+                          example: '2025-08-24T10:30:00Z'
+                      required:
+                        - id
+                        - user_id
+                        - organization_id
+                        - guardrail_id
+                        - assigned_by
+                        - created_at
+                    description: List of member assignments
+                  total_count:
+                    type: integer
+                    description: Total number of member assignments
+                    example: 10
+                required:
+                  - data
+                  - total_count
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Guardrail not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+    post:
+      operationId: bulkAssignMembersToGuardrail
+      x-speakeasy-name-override: bulkAssignMembers
+      tags:
+        - Guardrails
+      summary: Bulk assign members to a guardrail
+      description: >-
+        Assign multiple organization members to a specific guardrail. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail
+          name: id
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                member_user_ids:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                  minItems: 1
+                  description: Array of member user IDs to assign to the guardrail
+                  example:
+                    - user_abc123
+                    - user_def456
+              required:
+                - member_user_ids
+        required: true
+      responses:
+        '200':
+          description: Assignment result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  assigned_count:
+                    type: integer
+                    description: Number of members successfully assigned
+                    example: 2
+                required:
+                  - assigned_count
+        '400':
+          description: Bad Request - Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Guardrail not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /guardrails/{id}/assignments/keys/remove:
+    post:
+      operationId: bulkUnassignKeysFromGuardrail
+      x-speakeasy-name-override: bulkUnassignKeys
+      tags:
+        - Guardrails
+      summary: Bulk unassign keys from a guardrail
+      description: >-
+        Unassign multiple API keys from a specific guardrail. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail
+          name: id
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                key_hashes:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                  minItems: 1
+                  description: Array of API key hashes to unassign from the guardrail
+                  example:
+                    - c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93
+              required:
+                - key_hashes
+        required: true
+      responses:
+        '200':
+          description: Unassignment result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  unassigned_count:
+                    type: integer
+                    description: Number of keys successfully unassigned
+                    example: 3
+                required:
+                  - unassigned_count
+        '400':
+          description: Bad Request - Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Guardrail not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /guardrails/{id}/assignments/members/remove:
+    post:
+      operationId: bulkUnassignMembersFromGuardrail
+      x-speakeasy-name-override: bulkUnassignMembers
+      tags:
+        - Guardrails
+      summary: Bulk unassign members from a guardrail
+      description: >-
+        Unassign multiple organization members from a specific guardrail. [Management
+        key](/docs/guides/overview/auth/management-api-keys) required.
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the guardrail
+            example: 550e8400-e29b-41d4-a716-446655440000
+          required: true
+          description: The unique identifier of the guardrail
+          name: id
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                member_user_ids:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                  minItems: 1
+                  description: Array of member user IDs to unassign from the guardrail
+                  example:
+                    - user_abc123
+                    - user_def456
+              required:
+                - member_user_ids
+        required: true
+      responses:
+        '200':
+          description: Unassignment result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  unassigned_count:
+                    type: integer
+                    description: Number of members successfully unassigned
+                    example: 2
+                required:
+                  - unassigned_count
+        '400':
+          description: Bad Request - Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '404':
+          description: Guardrail not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /key:
+    get:
+      operationId: getCurrentKey
+      x-speakeasy-name-override: getCurrentKeyMetadata
+      tags:
+        - API Keys
+      summary: Get current API key
+      description: Get information on the API key associated with the current authentication session
+      responses:
+        '200':
+          description: API key details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      label:
+                        type: string
+                        description: Human-readable label for the API key
+                        example: sk-or-v1-0e6...1c96
+                      limit:
+                        type: number
+                        format: double
+                        description: Spending limit for the API key in USD
+                        example: 100
+                      usage:
+                        type: number
+                        format: double
+                        description: Total OpenRouter credit usage (in USD) for the API key
+                        example: 25.5
+                      usage_daily:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC day
+                        example: 25.5
+                      usage_weekly:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
+                        example: 25.5
+                      usage_monthly:
+                        type: number
+                        format: double
+                        description: OpenRouter credit usage (in USD) for the current UTC month
+                        example: 25.5
+                      byok_usage:
+                        type: number
+                        format: double
+                        description: Total external BYOK usage (in USD) for the API key
+                        example: 17.38
+                      byok_usage_daily:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for the current UTC day
+                        example: 17.38
+                      byok_usage_weekly:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
+                        example: 17.38
+                      byok_usage_monthly:
+                        type: number
+                        format: double
+                        description: External BYOK usage (in USD) for current UTC month
+                        example: 17.38
+                      is_free_tier:
+                        type: boolean
+                        description: Whether this is a free tier API key
+                        example: false
+                      is_management_key:
+                        type: boolean
+                        description: Whether this is a management key
+                        example: false
+                      is_provisioning_key:
+                        type: boolean
+                        description: Whether this is a management key
+                        deprecated: true
+                        example: false
+                      limit_remaining:
+                        type: number
+                        format: double
+                        description: Remaining spending limit in USD
+                        example: 74.5
+                      limit_reset:
+                        type: string
+                        nullable: true
+                        description: Type of limit reset for the API key
+                        example: monthly
+                      include_byok_in_limit:
+                        type: boolean
+                        description: Whether to include external BYOK usage in the credit limit
+                        example: false
+                      expires_at:
+                        type: string
+                        nullable: true
+                        format: date-time
+                        description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
+                        example: '2027-12-31T23:59:59Z'
+                      creator_user_id:
+                        type: string
+                        nullable: true
+                        description: >-
+                          The user ID of the key creator. For organization-owned keys, this is the member who created
+                          the key. For individual users, this is the user's own ID.
+                        example: user_2dHFtVWx2n56w6HkM0000000000
+                      rate_limit:
+                        type: object
+                        properties:
+                          requests:
+                            type: integer
+                            description: Number of requests allowed per interval
+                            example: 1000
+                          interval:
+                            type: string
+                            description: Rate limit interval
+                            example: 1h
+                          note:
+                            type: string
+                            description: Note about the rate limit
+                            example: This field is deprecated and safe to ignore.
+                        required:
+                          - requests
+                          - interval
+                          - note
+                        description: Legacy rate limit information about a key. Will always return -1.
+                        deprecated: true
+                        example:
+                          requests: 1000
+                          interval: 1h
+                          note: This field is deprecated and safe to ignore.
+                    required:
+                      - label
+                      - limit
+                      - usage
+                      - usage_daily
+                      - usage_weekly
+                      - usage_monthly
+                      - byok_usage
+                      - byok_usage_daily
+                      - byok_usage_weekly
+                      - byok_usage_monthly
+                      - is_free_tier
+                      - is_management_key
+                      - is_provisioning_key
+                      - limit_remaining
+                      - limit_reset
+                      - include_byok_in_limit
+                      - creator_user_id
+                      - rate_limit
+                    description: Current API key information
+                    example:
+                      label: sk-or-v1-au7...890
+                      limit: 100
+                      usage: 25.5
+                      usage_daily: 25.5
+                      usage_weekly: 25.5
+                      usage_monthly: 25.5
+                      byok_usage: 17.38
+                      byok_usage_daily: 17.38
+                      byok_usage_weekly: 17.38
+                      byok_usage_monthly: 17.38
+                      is_free_tier: false
+                      is_management_key: false
+                      is_provisioning_key: false
+                      limit_remaining: 74.5
+                      limit_reset: monthly
+                      include_byok_in_limit: false
+                      expires_at: '2027-12-31T23:59:59Z'
+                      creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+                      rate_limit:
+                        requests: 1000
+                        interval: 1h
+                        note: This field is deprecated and safe to ignore.
+                required:
+                  - data
+                example:
+                  data:
+                    label: sk-or-v1-au7...890
+                    limit: 100
+                    usage: 25.5
+                    usage_daily: 25.5
+                    usage_weekly: 25.5
+                    usage_monthly: 25.5
+                    byok_usage: 17.38
+                    byok_usage_daily: 17.38
+                    byok_usage_weekly: 17.38
+                    byok_usage_monthly: 17.38
+                    is_free_tier: false
+                    is_management_key: false
+                    is_provisioning_key: false
+                    limit_remaining: 74.5
+                    limit_reset: monthly
+                    include_byok_in_limit: false
+                    expires_at: '2027-12-31T23:59:59Z'
+                    creator_user_id: user_2dHFtVWx2n56w6HkM0000000000
+                    rate_limit:
+                      requests: 1000
+                      interval: 1h
+                      note: This field is deprecated and safe to ignore.
+        '401':
+          description: Unauthorized - Authentication required or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '500':
+          description: Internal Server Error - Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /auth/keys:
+    post:
+      operationId: exchangeAuthCodeForAPIKey
+      tags:
+        - OAuth
+      summary: Exchange authorization code for API key
+      description: Exchange an authorization code from the PKCE flow for a user-controlled API key
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                  description: The authorization code received from the OAuth redirect
+                  example: auth_code_abc123def456
+                code_verifier:
+                  type: string
+                  description: The code verifier if code_challenge was used in the authorization request
+                  example: dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+                code_challenge_method:
+                  type: string
+                  nullable: true
+                  enum:
+                    - S256
+                    - plain
+                  description: The method used to generate the code challenge
+                  example: S256
+              required:
+                - code
+              example:
+                code: auth_code_abc123def456
+                code_verifier: dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+                code_challenge_method: S256
+        required: true
+      responses:
+        '200':
+          description: Successfully exchanged code for an API key
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The API key to use for OpenRouter requests
+                    example: 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
+                  user_id:
+                    type: string
+                    nullable: true
+                    description: User ID associated with the API key
+                    example: user_2yOPcMpKoQhcd4bVgSMlELRaIah
+                required:
+                  - key
+                  - user_id
+                example:
+                  key: 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
+                  user_id: user_2yOPcMpKoQhcd4bVgSMlELRaIah
+        '400':
+          description: Bad Request - Invalid request parameters or malformed input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '403':
+          description: Forbidden - Authentication successful but insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+        '500':
+          description: Internal Server Error - Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+  /auth/keys/code:
+    post:
+      x-speakeasy-name-override: createAuthCode
+      tags:
+        - OAuth
+      summary: Create authorization code
+      description: Create an authorization code for the PKCE flow to generate a user-controlled API key
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                callback_url:
+                  type: string
+                  format: uri
+                  description: >-
+                    The callback URL to redirect to after authorization. Note, only https URLs on ports 443 and 3000 are
+                    allowed.
+                  example: https://myapp.com/auth/callback
+                code_challenge:
+                  type: string
+                  description: PKCE code challenge for enhanced security
+                  example: E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+                code_challenge_method:
+                  type: string
+                  enum:
+                    - S256
+                    - plain
+                  description: The method used to generate the code challenge
+                  example: S256
+                limit:
+                  type: number
+                  format: double
+                  description: Credit limit for the API key to be created
+                  example: 100
+                expires_at:
+                  type: string
+                  nullable: true
+                  format: date-time
+                  description: Optional expiration time for the API key to be created
+                key_label:
+                  type: string
+                  maxLength: 100
+                  description: Optional custom label for the API key. Defaults to the app name if not provided.
+                  example: My Custom Key
+                usage_limit_type:
+                  type: string
+                  enum:
+                    - daily
+                    - weekly
+                    - monthly
+                  description: Optional credit limit reset interval. When set, the credit limit resets on this interval.
+                  example: monthly
+                spawn_agent:
+                  type: string
+                  description: Agent identifier for spawn telemetry
+                  x-speakeasy-ignore: true
+                  x-fern-ignore: true
+                spawn_cloud:
+                  type: string
+                  description: Cloud identifier for spawn telemetry
+                  x-speakeasy-ignore: true
+                  x-fern-ignore: true
+              required:
+                - callback_url
+              example:
+                callback_url: https://myapp.com/auth/callback
+                code_challenge: E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+                code_challenge_method: S256
+                limit: 100
+        required: true
+      responses:
+        '200':
+          description: Successfully created authorization code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        description: The authorization code ID to use in the exchange request
+                        example: auth_code_xyz789
+                      app_id:
+                        type: integer
+                        description: The application ID associated with this auth code
+                        example: 12345
+                      created_at:
+                        type: string
+                        description: ISO 8601 timestamp of when the auth code was created
+                        example: '2025-08-24T10:30:00Z'
+                    required:
+                      - id
+                      - app_id
+                      - created_at
+                    description: Auth code data
+                    example:
+                      id: auth_code_xyz789
+                      app_id: 12345
+                      created_at: '2025-08-24T10:30:00Z'
+                required:
+                  - data
+        '400':
+          description: Bad Request - Invalid request parameters or malformed input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+        '401':
+          description: Unauthorized - Authentication required or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedResponse'
+        '409':
+          description: Conflict - App upsert conflict during auth code creation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConflictResponse'
+        '500':
+          description: Internal Server Error - Unexpected server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerResponse'
+      operationId: createAuthKeysCode
   /embeddings:
     post:
       x-speakeasy-name-override: generate
@@ -10172,3415 +19501,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalServerResponse'
       operationId: listEmbeddingsModels
-  /generation:
-    get:
-      tags:
-        - Generations
-      summary: Get request & usage metadata for a generation
-      parameters:
-        - schema:
-            type: string
-            minLength: 1
-          required: true
-          name: id
-          in: query
-      responses:
-        '200':
-          description: Returns the request metadata for this generation
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        description: Unique identifier for the generation
-                        example: gen-3bhGkxlo4XFrqiabUM7NDtwDzWwG
-                      upstream_id:
-                        type: string
-                        nullable: true
-                        description: Upstream provider's identifier for this generation
-                        example: chatcmpl-791bcf62-080e-4568-87d0-94c72e3b4946
-                      total_cost:
-                        type: number
-                        description: Total cost of the generation in USD
-                        example: 0.0015
-                      cache_discount:
-                        type: number
-                        nullable: true
-                        description: Discount applied due to caching
-                        example: 0.0002
-                      upstream_inference_cost:
-                        type: number
-                        nullable: true
-                        description: Cost charged by the upstream provider
-                        example: 0.0012
-                      created_at:
-                        type: string
-                        description: ISO 8601 timestamp of when the generation was created
-                        example: '2024-07-15T23:33:19.433273+00:00'
-                      model:
-                        type: string
-                        description: Model used for the generation
-                        example: sao10k/l3-stheno-8b
-                      app_id:
-                        type: number
-                        nullable: true
-                        description: ID of the app that made the request
-                        example: 12345
-                      streamed:
-                        type: boolean
-                        nullable: true
-                        description: Whether the response was streamed
-                        example: true
-                      cancelled:
-                        type: boolean
-                        nullable: true
-                        description: Whether the generation was cancelled
-                        example: false
-                      provider_name:
-                        type: string
-                        nullable: true
-                        description: Name of the provider that served the request
-                        example: Infermatic
-                      latency:
-                        type: number
-                        nullable: true
-                        description: Total latency in milliseconds
-                        example: 1250
-                      moderation_latency:
-                        type: number
-                        nullable: true
-                        description: Moderation latency in milliseconds
-                        example: 50
-                      generation_time:
-                        type: number
-                        nullable: true
-                        description: Time taken for generation in milliseconds
-                        example: 1200
-                      finish_reason:
-                        type: string
-                        nullable: true
-                        description: Reason the generation finished
-                        example: stop
-                      tokens_prompt:
-                        type: number
-                        nullable: true
-                        description: Number of tokens in the prompt
-                        example: 10
-                      tokens_completion:
-                        type: number
-                        nullable: true
-                        description: Number of tokens in the completion
-                        example: 25
-                      native_tokens_prompt:
-                        type: number
-                        nullable: true
-                        description: Native prompt tokens as reported by provider
-                        example: 10
-                      native_tokens_completion:
-                        type: number
-                        nullable: true
-                        description: Native completion tokens as reported by provider
-                        example: 25
-                      native_tokens_completion_images:
-                        type: number
-                        nullable: true
-                        description: Native completion image tokens as reported by provider
-                        example: 0
-                      native_tokens_reasoning:
-                        type: number
-                        nullable: true
-                        description: Native reasoning tokens as reported by provider
-                        example: 5
-                      native_tokens_cached:
-                        type: number
-                        nullable: true
-                        description: Native cached tokens as reported by provider
-                        example: 3
-                      num_media_prompt:
-                        type: number
-                        nullable: true
-                        description: Number of media items in the prompt
-                        example: 1
-                      num_input_audio_prompt:
-                        type: number
-                        nullable: true
-                        description: Number of audio inputs in the prompt
-                        example: 0
-                      num_media_completion:
-                        type: number
-                        nullable: true
-                        description: Number of media items in the completion
-                        example: 0
-                      num_search_results:
-                        type: number
-                        nullable: true
-                        description: Number of search results included
-                        example: 5
-                      origin:
-                        type: string
-                        description: Origin URL of the request
-                        example: https://openrouter.ai/
-                      usage:
-                        type: number
-                        description: Usage amount in USD
-                        example: 0.0015
-                      is_byok:
-                        type: boolean
-                        description: Whether this used bring-your-own-key
-                        example: false
-                      native_finish_reason:
-                        type: string
-                        nullable: true
-                        description: Native finish reason as reported by provider
-                        example: stop
-                      external_user:
-                        type: string
-                        nullable: true
-                        description: External user identifier
-                        example: user-123
-                      api_type:
-                        type: string
-                        nullable: true
-                        enum:
-                          - completions
-                          - embeddings
-                        description: Type of API used for the generation
-                      router:
-                        type: string
-                        nullable: true
-                        description: Router used for the request (e.g., openrouter/auto)
-                        example: openrouter/auto
-                    required:
-                      - id
-                      - upstream_id
-                      - total_cost
-                      - cache_discount
-                      - upstream_inference_cost
-                      - created_at
-                      - model
-                      - app_id
-                      - streamed
-                      - cancelled
-                      - provider_name
-                      - latency
-                      - moderation_latency
-                      - generation_time
-                      - finish_reason
-                      - tokens_prompt
-                      - tokens_completion
-                      - native_tokens_prompt
-                      - native_tokens_completion
-                      - native_tokens_completion_images
-                      - native_tokens_reasoning
-                      - native_tokens_cached
-                      - num_media_prompt
-                      - num_input_audio_prompt
-                      - num_media_completion
-                      - num_search_results
-                      - origin
-                      - usage
-                      - is_byok
-                      - native_finish_reason
-                      - external_user
-                      - api_type
-                      - router
-                    description: Generation data
-                required:
-                  - data
-                description: Generation response
-        '401':
-          description: Unauthorized - Authentication required or invalid credentials
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '402':
-          description: Payment Required - Insufficient credits or quota to complete request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaymentRequiredResponse'
-        '404':
-          description: Not Found - Generation not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '429':
-          description: Too Many Requests - Rate limit exceeded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TooManyRequestsResponse'
-        '500':
-          description: Internal Server Error - Unexpected server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-        '502':
-          description: Bad Gateway - Provider/upstream API failure
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadGatewayResponse'
-        '524':
-          description: Infrastructure Timeout - Request timed out at our edge network
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EdgeNetworkTimeoutResponse'
-        '529':
-          description: Provider Overloaded - Provider is temporarily overloaded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProviderOverloadedResponse'
-      operationId: getGeneration
-  /models/count:
-    get:
-      tags:
-        - Models
-      x-speakeasy-name-override: count
-      summary: Get total count of available models
-      responses:
-        '200':
-          description: Returns the total count of available models
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ModelsCountResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-      operationId: listModelsCount
-  /models:
-    get:
-      tags:
-        - Models
-      x-speakeasy-name-override: list
-      summary: List all models and their properties
-      parameters:
-        - schema:
-            type: string
-            enum:
-              - programming
-              - roleplay
-              - marketing
-              - marketing/seo
-              - technology
-              - science
-              - translation
-              - legal
-              - finance
-              - health
-              - trivia
-              - academia
-            description: Filter models by use case category
-            example: programming
-          required: false
-          description: Filter models by use case category
-          name: category
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: supported_parameters
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: use_rss
-          in: query
-        - schema:
-            type: string
-          required: false
-          name: use_rss_chat_links
-          in: query
-      responses:
-        '200':
-          description: Returns a list of models or RSS feed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ModelsListResponse'
-            application/rss+xml:
-              schema:
-                type: string
-        '400':
-          description: Bad Request - Invalid request parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-      operationId: getModels
-  /models/user:
-    get:
-      tags:
-        - Models
-      x-speakeasy-name-override: listForUser
-      description: >-
-        List models filtered by user provider preferences, [privacy
-        settings](https://openrouter.ai/docs/guides/privacy/logging), and
-        [guardrails](https://openrouter.ai/docs/guides/features/guardrails). If requesting through
-        `eu.openrouter.ai/api/v1/...` the results will be filtered to models that satisfy [EU in-region
-        routing](https://openrouter.ai/docs/guides/privacy/logging#enterprise-eu-in-region-routing).
-      summary: List models filtered by user provider preferences, privacy settings, and guardrails
-      security:
-        - bearer: []
-      responses:
-        '200':
-          description: Returns a list of models filtered by user provider preferences
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ModelsListResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Not Found - No eligible endpoints found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-      operationId: listModelsUser
-  /models/{author}/{slug}/endpoints:
-    get:
-      tags:
-        - Endpoints
-      operationId: listEndpoints
-      x-speakeasy-name-override: list
-      summary: List all endpoints for a model
-      parameters:
-        - schema:
-            type: string
-          required: true
-          name: author
-          in: path
-        - schema:
-            type: string
-          required: true
-          name: slug
-          in: path
-      responses:
-        '200':
-          description: Returns a list of endpoints
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ListEndpointsResponse'
-                required:
-                  - data
-        '404':
-          description: Not Found - Model does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error - Unexpected server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /endpoints/zdr:
-    get:
-      tags:
-        - Endpoints
-      x-speakeasy-name-override: listZdrEndpoints
-      summary: Preview the impact of ZDR on the available endpoints
-      responses:
-        '200':
-          description: Returns a list of endpoints
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PublicEndpoint'
-                required:
-                  - data
-        '500':
-          description: Internal Server Error - Unexpected server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-      operationId: listEndpointsZdr
-  /providers:
-    get:
-      tags:
-        - Providers
-      x-speakeasy-name-override: list
-      summary: List all providers
-      operationId: listProviders
-      responses:
-        '200':
-          description: Returns a list of providers
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: Display name of the provider
-                          example: OpenAI
-                        slug:
-                          type: string
-                          description: URL-friendly identifier for the provider
-                          example: openai
-                        privacy_policy_url:
-                          type: string
-                          nullable: true
-                          description: URL to the provider's privacy policy
-                          example: https://openai.com/privacy
-                        terms_of_service_url:
-                          type: string
-                          nullable: true
-                          description: URL to the provider's terms of service
-                          example: https://openai.com/terms
-                        status_page_url:
-                          type: string
-                          nullable: true
-                          description: URL to the provider's status page
-                          example: https://status.openai.com
-                      required:
-                        - name
-                        - slug
-                        - privacy_policy_url
-                      example:
-                        name: OpenAI
-                        slug: openai
-                        privacy_policy_url: https://openai.com/privacy
-                        terms_of_service_url: https://openai.com/terms
-                        status_page_url: https://status.openai.com
-                required:
-                  - data
-        '500':
-          description: Internal Server Error - Unexpected server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /keys:
-    get:
-      operationId: list
-      x-speakeasy-name-override: list
-      tags:
-        - API Keys
-      summary: List API keys
-      description: >-
-        List all API keys for the authenticated user. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            description: Whether to include disabled API keys in the response
-            example: 'false'
-          required: false
-          description: Whether to include disabled API keys in the response
-          name: include_disabled
-          in: query
-        - schema:
-            type: string
-            description: Number of API keys to skip for pagination
-            example: '0'
-          required: false
-          description: Number of API keys to skip for pagination
-          name: offset
-          in: query
-      responses:
-        '200':
-          description: List of API keys
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        hash:
-                          type: string
-                          description: Unique hash identifier for the API key
-                          example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                        name:
-                          type: string
-                          description: Name of the API key
-                          example: My Production Key
-                        label:
-                          type: string
-                          description: Human-readable label for the API key
-                          example: sk-or-v1-0e6...1c96
-                        disabled:
-                          type: boolean
-                          description: Whether the API key is disabled
-                          example: false
-                        limit:
-                          type: number
-                          nullable: true
-                          description: Spending limit for the API key in USD
-                          example: 100
-                        limit_remaining:
-                          type: number
-                          nullable: true
-                          description: Remaining spending limit in USD
-                          example: 74.5
-                        limit_reset:
-                          type: string
-                          nullable: true
-                          description: Type of limit reset for the API key
-                          example: monthly
-                        include_byok_in_limit:
-                          type: boolean
-                          description: Whether to include external BYOK usage in the credit limit
-                          example: false
-                        usage:
-                          type: number
-                          description: Total OpenRouter credit usage (in USD) for the API key
-                          example: 25.5
-                        usage_daily:
-                          type: number
-                          description: OpenRouter credit usage (in USD) for the current UTC day
-                          example: 25.5
-                        usage_weekly:
-                          type: number
-                          description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
-                          example: 25.5
-                        usage_monthly:
-                          type: number
-                          description: OpenRouter credit usage (in USD) for the current UTC month
-                          example: 25.5
-                        byok_usage:
-                          type: number
-                          description: Total external BYOK usage (in USD) for the API key
-                          example: 17.38
-                        byok_usage_daily:
-                          type: number
-                          description: External BYOK usage (in USD) for the current UTC day
-                          example: 17.38
-                        byok_usage_weekly:
-                          type: number
-                          description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
-                          example: 17.38
-                        byok_usage_monthly:
-                          type: number
-                          description: External BYOK usage (in USD) for current UTC month
-                          example: 17.38
-                        created_at:
-                          type: string
-                          description: ISO 8601 timestamp of when the API key was created
-                          example: '2025-08-24T10:30:00Z'
-                        updated_at:
-                          type: string
-                          nullable: true
-                          description: ISO 8601 timestamp of when the API key was last updated
-                          example: '2025-08-24T15:45:00Z'
-                        expires_at:
-                          type: string
-                          nullable: true
-                          format: date-time
-                          description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
-                          example: '2027-12-31T23:59:59Z'
-                      required:
-                        - hash
-                        - name
-                        - label
-                        - disabled
-                        - limit
-                        - limit_remaining
-                        - limit_reset
-                        - include_byok_in_limit
-                        - usage
-                        - usage_daily
-                        - usage_weekly
-                        - usage_monthly
-                        - byok_usage
-                        - byok_usage_daily
-                        - byok_usage_weekly
-                        - byok_usage_monthly
-                        - created_at
-                        - updated_at
-                      example:
-                        hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                        name: My Production Key
-                        label: sk-or-v1-0e6...1c96
-                        disabled: false
-                        limit: 100
-                        limit_remaining: 74.5
-                        limit_reset: monthly
-                        include_byok_in_limit: false
-                        usage: 25.5
-                        usage_daily: 25.5
-                        usage_weekly: 25.5
-                        usage_monthly: 25.5
-                        byok_usage: 17.38
-                        byok_usage_daily: 17.38
-                        byok_usage_weekly: 17.38
-                        byok_usage_monthly: 17.38
-                        created_at: '2025-08-24T10:30:00Z'
-                        updated_at: '2025-08-24T15:45:00Z'
-                        expires_at: '2027-12-31T23:59:59Z'
-                    description: List of API keys
-                required:
-                  - data
-                example:
-                  data:
-                    - hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                      name: My Production Key
-                      label: Production API Key
-                      disabled: false
-                      limit: 100
-                      limit_remaining: 74.5
-                      limit_reset: monthly
-                      include_byok_in_limit: false
-                      usage: 25.5
-                      usage_daily: 25.5
-                      usage_weekly: 25.5
-                      usage_monthly: 25.5
-                      byok_usage: 17.38
-                      byok_usage_daily: 17.38
-                      byok_usage_weekly: 17.38
-                      byok_usage_monthly: 17.38
-                      created_at: '2025-08-24T10:30:00Z'
-                      updated_at: '2025-08-24T15:45:00Z'
-                      expires_at: '2027-12-31T23:59:59Z'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '429':
-          description: Too Many Requests - Rate limit exceeded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TooManyRequestsResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-    post:
-      x-speakeasy-name-override: create
-      tags:
-        - API Keys
-      summary: Create a new API key
-      description: >-
-        Create a new API key for the authenticated user. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                  description: Name for the new API key
-                  example: My New API Key
-                limit:
-                  type: number
-                  nullable: true
-                  description: Optional spending limit for the API key in USD
-                  example: 50
-                limit_reset:
-                  type: string
-                  nullable: true
-                  enum:
-                    - daily
-                    - weekly
-                    - monthly
-                  description: >-
-                    Type of limit reset for the API key (daily, weekly, monthly, or null for no reset). Resets happen
-                    automatically at midnight UTC, and weeks are Monday through Sunday.
-                  example: monthly
-                include_byok_in_limit:
-                  type: boolean
-                  description: Whether to include BYOK usage in the limit
-                  example: true
-                expires_at:
-                  type: string
-                  nullable: true
-                  format: date-time
-                  description: >-
-                    Optional ISO 8601 UTC timestamp when the API key should expire. Must be UTC, other timezones will be
-                    rejected
-                  example: '2027-12-31T23:59:59Z'
-              required:
-                - name
-              example:
-                name: My New API Key
-                limit: 50
-                limit_reset: monthly
-                include_byok_in_limit: true
-                expires_at: '2027-12-31T23:59:59Z'
-        required: true
-      responses:
-        '201':
-          description: API key created successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      hash:
-                        type: string
-                        description: Unique hash identifier for the API key
-                        example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                      name:
-                        type: string
-                        description: Name of the API key
-                        example: My Production Key
-                      label:
-                        type: string
-                        description: Human-readable label for the API key
-                        example: sk-or-v1-0e6...1c96
-                      disabled:
-                        type: boolean
-                        description: Whether the API key is disabled
-                        example: false
-                      limit:
-                        type: number
-                        nullable: true
-                        description: Spending limit for the API key in USD
-                        example: 100
-                      limit_remaining:
-                        type: number
-                        nullable: true
-                        description: Remaining spending limit in USD
-                        example: 74.5
-                      limit_reset:
-                        type: string
-                        nullable: true
-                        description: Type of limit reset for the API key
-                        example: monthly
-                      include_byok_in_limit:
-                        type: boolean
-                        description: Whether to include external BYOK usage in the credit limit
-                        example: false
-                      usage:
-                        type: number
-                        description: Total OpenRouter credit usage (in USD) for the API key
-                        example: 25.5
-                      usage_daily:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC day
-                        example: 25.5
-                      usage_weekly:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
-                        example: 25.5
-                      usage_monthly:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC month
-                        example: 25.5
-                      byok_usage:
-                        type: number
-                        description: Total external BYOK usage (in USD) for the API key
-                        example: 17.38
-                      byok_usage_daily:
-                        type: number
-                        description: External BYOK usage (in USD) for the current UTC day
-                        example: 17.38
-                      byok_usage_weekly:
-                        type: number
-                        description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
-                        example: 17.38
-                      byok_usage_monthly:
-                        type: number
-                        description: External BYOK usage (in USD) for current UTC month
-                        example: 17.38
-                      created_at:
-                        type: string
-                        description: ISO 8601 timestamp of when the API key was created
-                        example: '2025-08-24T10:30:00Z'
-                      updated_at:
-                        type: string
-                        nullable: true
-                        description: ISO 8601 timestamp of when the API key was last updated
-                        example: '2025-08-24T15:45:00Z'
-                      expires_at:
-                        type: string
-                        nullable: true
-                        format: date-time
-                        description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
-                        example: '2027-12-31T23:59:59Z'
-                    required:
-                      - hash
-                      - name
-                      - label
-                      - disabled
-                      - limit
-                      - limit_remaining
-                      - limit_reset
-                      - include_byok_in_limit
-                      - usage
-                      - usage_daily
-                      - usage_weekly
-                      - usage_monthly
-                      - byok_usage
-                      - byok_usage_daily
-                      - byok_usage_weekly
-                      - byok_usage_monthly
-                      - created_at
-                      - updated_at
-                    example:
-                      hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                      name: My Production Key
-                      label: sk-or-v1-0e6...1c96
-                      disabled: false
-                      limit: 100
-                      limit_remaining: 74.5
-                      limit_reset: monthly
-                      include_byok_in_limit: false
-                      usage: 25.5
-                      usage_daily: 25.5
-                      usage_weekly: 25.5
-                      usage_monthly: 25.5
-                      byok_usage: 17.38
-                      byok_usage_daily: 17.38
-                      byok_usage_weekly: 17.38
-                      byok_usage_monthly: 17.38
-                      created_at: '2025-08-24T10:30:00Z'
-                      updated_at: '2025-08-24T15:45:00Z'
-                      expires_at: '2027-12-31T23:59:59Z'
-                    description: The created API key information
-                  key:
-                    type: string
-                    description: The actual API key string (only shown once)
-                    example: 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
-                required:
-                  - data
-                  - key
-                example:
-                  data:
-                    hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                    name: My New API Key
-                    label: My New API Key
-                    disabled: false
-                    limit: 50
-                    limit_remaining: 50
-                    limit_reset: monthly
-                    include_byok_in_limit: true
-                    usage: 0
-                    usage_daily: 0
-                    usage_weekly: 0
-                    usage_monthly: 0
-                    byok_usage: 0
-                    byok_usage_daily: 0
-                    byok_usage_weekly: 0
-                    byok_usage_monthly: 0
-                    created_at: '2025-08-24T10:30:00Z'
-                    updated_at: null
-                    expires_at: '2027-12-31T23:59:59Z'
-                  key: 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
-        '400':
-          description: Bad Request - Invalid request parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '429':
-          description: Too Many Requests - Rate limit exceeded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TooManyRequestsResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-      operationId: createKeys
-  /keys/{hash}:
-    patch:
-      x-speakeasy-name-override: update
-      tags:
-        - API Keys
-      summary: Update an API key
-      description: Update an existing API key. [Provisioning key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            description: The hash identifier of the API key to update
-            example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-          required: true
-          description: The hash identifier of the API key to update
-          name: hash
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  description: New name for the API key
-                  example: Updated API Key Name
-                disabled:
-                  type: boolean
-                  description: Whether to disable the API key
-                  example: false
-                limit:
-                  type: number
-                  nullable: true
-                  description: New spending limit for the API key in USD
-                  example: 75
-                limit_reset:
-                  type: string
-                  nullable: true
-                  enum:
-                    - daily
-                    - weekly
-                    - monthly
-                  description: >-
-                    New limit reset type for the API key (daily, weekly, monthly, or null for no reset). Resets happen
-                    automatically at midnight UTC, and weeks are Monday through Sunday.
-                  example: daily
-                include_byok_in_limit:
-                  type: boolean
-                  description: Whether to include BYOK usage in the limit
-                  example: true
-              example:
-                name: Updated API Key Name
-                disabled: false
-                limit: 75
-                limit_reset: daily
-                include_byok_in_limit: true
-        required: true
-      responses:
-        '200':
-          description: API key updated successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      hash:
-                        type: string
-                        description: Unique hash identifier for the API key
-                        example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                      name:
-                        type: string
-                        description: Name of the API key
-                        example: My Production Key
-                      label:
-                        type: string
-                        description: Human-readable label for the API key
-                        example: sk-or-v1-0e6...1c96
-                      disabled:
-                        type: boolean
-                        description: Whether the API key is disabled
-                        example: false
-                      limit:
-                        type: number
-                        nullable: true
-                        description: Spending limit for the API key in USD
-                        example: 100
-                      limit_remaining:
-                        type: number
-                        nullable: true
-                        description: Remaining spending limit in USD
-                        example: 74.5
-                      limit_reset:
-                        type: string
-                        nullable: true
-                        description: Type of limit reset for the API key
-                        example: monthly
-                      include_byok_in_limit:
-                        type: boolean
-                        description: Whether to include external BYOK usage in the credit limit
-                        example: false
-                      usage:
-                        type: number
-                        description: Total OpenRouter credit usage (in USD) for the API key
-                        example: 25.5
-                      usage_daily:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC day
-                        example: 25.5
-                      usage_weekly:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
-                        example: 25.5
-                      usage_monthly:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC month
-                        example: 25.5
-                      byok_usage:
-                        type: number
-                        description: Total external BYOK usage (in USD) for the API key
-                        example: 17.38
-                      byok_usage_daily:
-                        type: number
-                        description: External BYOK usage (in USD) for the current UTC day
-                        example: 17.38
-                      byok_usage_weekly:
-                        type: number
-                        description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
-                        example: 17.38
-                      byok_usage_monthly:
-                        type: number
-                        description: External BYOK usage (in USD) for current UTC month
-                        example: 17.38
-                      created_at:
-                        type: string
-                        description: ISO 8601 timestamp of when the API key was created
-                        example: '2025-08-24T10:30:00Z'
-                      updated_at:
-                        type: string
-                        nullable: true
-                        description: ISO 8601 timestamp of when the API key was last updated
-                        example: '2025-08-24T15:45:00Z'
-                      expires_at:
-                        type: string
-                        nullable: true
-                        format: date-time
-                        description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
-                        example: '2027-12-31T23:59:59Z'
-                    required:
-                      - hash
-                      - name
-                      - label
-                      - disabled
-                      - limit
-                      - limit_remaining
-                      - limit_reset
-                      - include_byok_in_limit
-                      - usage
-                      - usage_daily
-                      - usage_weekly
-                      - usage_monthly
-                      - byok_usage
-                      - byok_usage_daily
-                      - byok_usage_weekly
-                      - byok_usage_monthly
-                      - created_at
-                      - updated_at
-                    example:
-                      hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                      name: My Production Key
-                      label: sk-or-v1-0e6...1c96
-                      disabled: false
-                      limit: 100
-                      limit_remaining: 74.5
-                      limit_reset: monthly
-                      include_byok_in_limit: false
-                      usage: 25.5
-                      usage_daily: 25.5
-                      usage_weekly: 25.5
-                      usage_monthly: 25.5
-                      byok_usage: 17.38
-                      byok_usage_daily: 17.38
-                      byok_usage_weekly: 17.38
-                      byok_usage_monthly: 17.38
-                      created_at: '2025-08-24T10:30:00Z'
-                      updated_at: '2025-08-24T15:45:00Z'
-                      expires_at: '2027-12-31T23:59:59Z'
-                    description: The updated API key information
-                required:
-                  - data
-                example:
-                  data:
-                    hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                    name: Updated API Key Name
-                    label: Updated API Key Name
-                    disabled: false
-                    limit: 75
-                    limit_remaining: 49.5
-                    limit_reset: daily
-                    include_byok_in_limit: true
-                    usage: 25.5
-                    usage_daily: 25.5
-                    usage_weekly: 25.5
-                    usage_monthly: 25.5
-                    byok_usage: 17.38
-                    byok_usage_daily: 17.38
-                    byok_usage_weekly: 17.38
-                    byok_usage_monthly: 17.38
-                    created_at: '2025-08-24T10:30:00Z'
-                    updated_at: '2025-08-24T16:00:00Z'
-                    expires_at: null
-        '400':
-          description: Bad Request - Invalid request parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Not Found - API key does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '429':
-          description: Too Many Requests - Rate limit exceeded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TooManyRequestsResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-      operationId: updateKeys
-    delete:
-      x-speakeasy-name-override: delete
-      tags:
-        - API Keys
-      summary: Delete an API key
-      description: Delete an existing API key. [Provisioning key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            description: The hash identifier of the API key to delete
-            example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-          required: true
-          description: The hash identifier of the API key to delete
-          name: hash
-          in: path
-      responses:
-        '200':
-          description: API key deleted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  deleted:
-                    type: boolean
-                    const: true
-                    description: Confirmation that the API key was deleted
-                    example: true
-                required:
-                  - deleted
-                example:
-                  deleted: true
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Not Found - API key does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '429':
-          description: Too Many Requests - Rate limit exceeded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TooManyRequestsResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-      operationId: deleteKeys
-    get:
-      operationId: getKey
-      x-speakeasy-name-override: get
-      tags:
-        - API Keys
-      summary: Get a single API key
-      description: Get a single API key by hash. [Provisioning key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            description: The hash identifier of the API key to retrieve
-            example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-          required: true
-          description: The hash identifier of the API key to retrieve
-          name: hash
-          in: path
-      responses:
-        '200':
-          description: API key details
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      hash:
-                        type: string
-                        description: Unique hash identifier for the API key
-                        example: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                      name:
-                        type: string
-                        description: Name of the API key
-                        example: My Production Key
-                      label:
-                        type: string
-                        description: Human-readable label for the API key
-                        example: sk-or-v1-0e6...1c96
-                      disabled:
-                        type: boolean
-                        description: Whether the API key is disabled
-                        example: false
-                      limit:
-                        type: number
-                        nullable: true
-                        description: Spending limit for the API key in USD
-                        example: 100
-                      limit_remaining:
-                        type: number
-                        nullable: true
-                        description: Remaining spending limit in USD
-                        example: 74.5
-                      limit_reset:
-                        type: string
-                        nullable: true
-                        description: Type of limit reset for the API key
-                        example: monthly
-                      include_byok_in_limit:
-                        type: boolean
-                        description: Whether to include external BYOK usage in the credit limit
-                        example: false
-                      usage:
-                        type: number
-                        description: Total OpenRouter credit usage (in USD) for the API key
-                        example: 25.5
-                      usage_daily:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC day
-                        example: 25.5
-                      usage_weekly:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
-                        example: 25.5
-                      usage_monthly:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC month
-                        example: 25.5
-                      byok_usage:
-                        type: number
-                        description: Total external BYOK usage (in USD) for the API key
-                        example: 17.38
-                      byok_usage_daily:
-                        type: number
-                        description: External BYOK usage (in USD) for the current UTC day
-                        example: 17.38
-                      byok_usage_weekly:
-                        type: number
-                        description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
-                        example: 17.38
-                      byok_usage_monthly:
-                        type: number
-                        description: External BYOK usage (in USD) for current UTC month
-                        example: 17.38
-                      created_at:
-                        type: string
-                        description: ISO 8601 timestamp of when the API key was created
-                        example: '2025-08-24T10:30:00Z'
-                      updated_at:
-                        type: string
-                        nullable: true
-                        description: ISO 8601 timestamp of when the API key was last updated
-                        example: '2025-08-24T15:45:00Z'
-                      expires_at:
-                        type: string
-                        nullable: true
-                        format: date-time
-                        description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
-                        example: '2027-12-31T23:59:59Z'
-                    required:
-                      - hash
-                      - name
-                      - label
-                      - disabled
-                      - limit
-                      - limit_remaining
-                      - limit_reset
-                      - include_byok_in_limit
-                      - usage
-                      - usage_daily
-                      - usage_weekly
-                      - usage_monthly
-                      - byok_usage
-                      - byok_usage_daily
-                      - byok_usage_weekly
-                      - byok_usage_monthly
-                      - created_at
-                      - updated_at
-                    example:
-                      hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                      name: My Production Key
-                      label: sk-or-v1-0e6...1c96
-                      disabled: false
-                      limit: 100
-                      limit_remaining: 74.5
-                      limit_reset: monthly
-                      include_byok_in_limit: false
-                      usage: 25.5
-                      usage_daily: 25.5
-                      usage_weekly: 25.5
-                      usage_monthly: 25.5
-                      byok_usage: 17.38
-                      byok_usage_daily: 17.38
-                      byok_usage_weekly: 17.38
-                      byok_usage_monthly: 17.38
-                      created_at: '2025-08-24T10:30:00Z'
-                      updated_at: '2025-08-24T15:45:00Z'
-                      expires_at: '2027-12-31T23:59:59Z'
-                    description: The API key information
-                required:
-                  - data
-                example:
-                  data:
-                    hash: f01d52606dc8f0a8303a7b5cc3fa07109c2e346cec7c0a16b40de462992ce943
-                    name: My Production Key
-                    label: Production API Key
-                    disabled: false
-                    limit: 100
-                    limit_remaining: 74.5
-                    limit_reset: monthly
-                    include_byok_in_limit: false
-                    usage: 25.5
-                    usage_daily: 25.5
-                    usage_weekly: 25.5
-                    usage_monthly: 25.5
-                    byok_usage: 17.38
-                    byok_usage_daily: 17.38
-                    byok_usage_weekly: 17.38
-                    byok_usage_monthly: 17.38
-                    created_at: '2025-08-24T10:30:00Z'
-                    updated_at: '2025-08-24T15:45:00Z'
-                    expires_at: '2027-12-31T23:59:59Z'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Not Found - API key does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '429':
-          description: Too Many Requests - Rate limit exceeded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TooManyRequestsResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /guardrails:
-    get:
-      operationId: listGuardrails
-      x-speakeasy-name-override: list
-      tags:
-        - Guardrails
-      summary: List guardrails
-      description: >-
-        List all guardrails for the authenticated user. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            description: Number of records to skip for pagination
-            example: '0'
-          required: false
-          description: Number of records to skip for pagination
-          name: offset
-          in: query
-        - schema:
-            type: string
-            description: Maximum number of records to return (max 100)
-            example: '50'
-          required: false
-          description: Maximum number of records to return (max 100)
-          name: limit
-          in: query
-      responses:
-        '200':
-          description: List of guardrails
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          format: uuid
-                          description: Unique identifier for the guardrail
-                          example: 550e8400-e29b-41d4-a716-446655440000
-                        name:
-                          type: string
-                          description: Name of the guardrail
-                          example: Production Guardrail
-                        description:
-                          type: string
-                          nullable: true
-                          description: Description of the guardrail
-                          example: Guardrail for production environment
-                        limit_usd:
-                          type: number
-                          nullable: true
-                          minimum: 0
-                          exclusiveMinimum: true
-                          description: Spending limit in USD
-                          example: 100
-                        reset_interval:
-                          type: string
-                          nullable: true
-                          enum:
-                            - daily
-                            - weekly
-                            - monthly
-                          description: Interval at which the limit resets (daily, weekly, monthly)
-                          example: monthly
-                        allowed_providers:
-                          type: array
-                          nullable: true
-                          items:
-                            type: string
-                          description: List of allowed provider IDs
-                          example:
-                            - openai
-                            - anthropic
-                            - google
-                        allowed_models:
-                          type: array
-                          nullable: true
-                          items:
-                            type: string
-                          description: Array of model canonical_slugs (immutable identifiers)
-                          example:
-                            - openai/gpt-5.2-20251211
-                            - anthropic/claude-4.5-opus-20251124
-                            - deepseek/deepseek-r1-0528:free
-                        enforce_zdr:
-                          type: boolean
-                          nullable: true
-                          description: Whether to enforce zero data retention
-                          example: false
-                        created_at:
-                          type: string
-                          description: ISO 8601 timestamp of when the guardrail was created
-                          example: '2025-08-24T10:30:00Z'
-                        updated_at:
-                          type: string
-                          nullable: true
-                          description: ISO 8601 timestamp of when the guardrail was last updated
-                          example: '2025-08-24T15:45:00Z'
-                      required:
-                        - id
-                        - name
-                        - created_at
-                      example:
-                        id: 550e8400-e29b-41d4-a716-446655440000
-                        name: Production Guardrail
-                        description: Guardrail for production environment
-                        limit_usd: 100
-                        reset_interval: monthly
-                        allowed_providers:
-                          - openai
-                          - anthropic
-                          - google
-                        allowed_models: null
-                        enforce_zdr: false
-                        created_at: '2025-08-24T10:30:00Z'
-                        updated_at: '2025-08-24T15:45:00Z'
-                    description: List of guardrails
-                  total_count:
-                    type: number
-                    description: Total number of guardrails
-                    example: 25
-                required:
-                  - data
-                  - total_count
-                example:
-                  data:
-                    - id: 550e8400-e29b-41d4-a716-446655440000
-                      name: Production Guardrail
-                      description: Guardrail for production environment
-                      limit_usd: 100
-                      reset_interval: monthly
-                      allowed_providers:
-                        - openai
-                        - anthropic
-                        - google
-                      allowed_models: null
-                      enforce_zdr: false
-                      created_at: '2025-08-24T10:30:00Z'
-                      updated_at: '2025-08-24T15:45:00Z'
-                  total_count: 1
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-    post:
-      operationId: createGuardrail
-      x-speakeasy-name-override: create
-      tags:
-        - Guardrails
-      summary: Create a guardrail
-      description: >-
-        Create a new guardrail for the authenticated user. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                  maxLength: 200
-                  description: Name for the new guardrail
-                  example: My New Guardrail
-                description:
-                  type: string
-                  nullable: true
-                  maxLength: 1000
-                  description: Description of the guardrail
-                  example: A guardrail for limiting API usage
-                limit_usd:
-                  type: number
-                  nullable: true
-                  minimum: 0
-                  exclusiveMinimum: true
-                  description: Spending limit in USD
-                  example: 50
-                reset_interval:
-                  type: string
-                  nullable: true
-                  enum:
-                    - daily
-                    - weekly
-                    - monthly
-                  description: Interval at which the limit resets (daily, weekly, monthly)
-                  example: monthly
-                allowed_providers:
-                  type: array
-                  nullable: true
-                  items:
-                    type: string
-                  minItems: 1
-                  description: List of allowed provider IDs
-                  example:
-                    - openai
-                    - anthropic
-                    - deepseek
-                allowed_models:
-                  type: array
-                  nullable: true
-                  items:
-                    type: string
-                  minItems: 1
-                  description: Array of model identifiers (slug or canonical_slug accepted)
-                  example:
-                    - openai/gpt-5.2
-                    - anthropic/claude-4.5-opus-20251124
-                    - deepseek/deepseek-r1-0528:free
-                enforce_zdr:
-                  type: boolean
-                  nullable: true
-                  description: Whether to enforce zero data retention
-                  example: false
-              required:
-                - name
-              example:
-                name: My New Guardrail
-                description: A guardrail for limiting API usage
-                limit_usd: 50
-                reset_interval: monthly
-                allowed_providers:
-                  - openai
-                  - anthropic
-                  - deepseek
-                allowed_models: null
-                enforce_zdr: false
-        required: true
-      responses:
-        '201':
-          description: Guardrail created successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        format: uuid
-                        description: Unique identifier for the guardrail
-                        example: 550e8400-e29b-41d4-a716-446655440000
-                      name:
-                        type: string
-                        description: Name of the guardrail
-                        example: Production Guardrail
-                      description:
-                        type: string
-                        nullable: true
-                        description: Description of the guardrail
-                        example: Guardrail for production environment
-                      limit_usd:
-                        type: number
-                        nullable: true
-                        minimum: 0
-                        exclusiveMinimum: true
-                        description: Spending limit in USD
-                        example: 100
-                      reset_interval:
-                        type: string
-                        nullable: true
-                        enum:
-                          - daily
-                          - weekly
-                          - monthly
-                        description: Interval at which the limit resets (daily, weekly, monthly)
-                        example: monthly
-                      allowed_providers:
-                        type: array
-                        nullable: true
-                        items:
-                          type: string
-                        description: List of allowed provider IDs
-                        example:
-                          - openai
-                          - anthropic
-                          - google
-                      allowed_models:
-                        type: array
-                        nullable: true
-                        items:
-                          type: string
-                        description: Array of model canonical_slugs (immutable identifiers)
-                        example:
-                          - openai/gpt-5.2-20251211
-                          - anthropic/claude-4.5-opus-20251124
-                          - deepseek/deepseek-r1-0528:free
-                      enforce_zdr:
-                        type: boolean
-                        nullable: true
-                        description: Whether to enforce zero data retention
-                        example: false
-                      created_at:
-                        type: string
-                        description: ISO 8601 timestamp of when the guardrail was created
-                        example: '2025-08-24T10:30:00Z'
-                      updated_at:
-                        type: string
-                        nullable: true
-                        description: ISO 8601 timestamp of when the guardrail was last updated
-                        example: '2025-08-24T15:45:00Z'
-                    required:
-                      - id
-                      - name
-                      - created_at
-                    example:
-                      id: 550e8400-e29b-41d4-a716-446655440000
-                      name: Production Guardrail
-                      description: Guardrail for production environment
-                      limit_usd: 100
-                      reset_interval: monthly
-                      allowed_providers:
-                        - openai
-                        - anthropic
-                        - google
-                      allowed_models: null
-                      enforce_zdr: false
-                      created_at: '2025-08-24T10:30:00Z'
-                      updated_at: '2025-08-24T15:45:00Z'
-                    description: The created guardrail
-                required:
-                  - data
-                example:
-                  data:
-                    id: 550e8400-e29b-41d4-a716-446655440000
-                    name: My New Guardrail
-                    description: A guardrail for limiting API usage
-                    limit_usd: 50
-                    reset_interval: monthly
-                    allowed_providers:
-                      - openai
-                      - anthropic
-                      - google
-                    allowed_models: null
-                    enforce_zdr: false
-                    created_at: '2025-08-24T10:30:00Z'
-                    updated_at: null
-        '400':
-          description: Bad Request - Invalid request parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /guardrails/{id}:
-    get:
-      operationId: getGuardrail
-      x-speakeasy-name-override: get
-      tags:
-        - Guardrails
-      summary: Get a guardrail
-      description: Get a single guardrail by ID. [Provisioning key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail to retrieve
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail to retrieve
-          name: id
-          in: path
-      responses:
-        '200':
-          description: Guardrail details
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        format: uuid
-                        description: Unique identifier for the guardrail
-                        example: 550e8400-e29b-41d4-a716-446655440000
-                      name:
-                        type: string
-                        description: Name of the guardrail
-                        example: Production Guardrail
-                      description:
-                        type: string
-                        nullable: true
-                        description: Description of the guardrail
-                        example: Guardrail for production environment
-                      limit_usd:
-                        type: number
-                        nullable: true
-                        minimum: 0
-                        exclusiveMinimum: true
-                        description: Spending limit in USD
-                        example: 100
-                      reset_interval:
-                        type: string
-                        nullable: true
-                        enum:
-                          - daily
-                          - weekly
-                          - monthly
-                        description: Interval at which the limit resets (daily, weekly, monthly)
-                        example: monthly
-                      allowed_providers:
-                        type: array
-                        nullable: true
-                        items:
-                          type: string
-                        description: List of allowed provider IDs
-                        example:
-                          - openai
-                          - anthropic
-                          - google
-                      allowed_models:
-                        type: array
-                        nullable: true
-                        items:
-                          type: string
-                        description: Array of model canonical_slugs (immutable identifiers)
-                        example:
-                          - openai/gpt-5.2-20251211
-                          - anthropic/claude-4.5-opus-20251124
-                          - deepseek/deepseek-r1-0528:free
-                      enforce_zdr:
-                        type: boolean
-                        nullable: true
-                        description: Whether to enforce zero data retention
-                        example: false
-                      created_at:
-                        type: string
-                        description: ISO 8601 timestamp of when the guardrail was created
-                        example: '2025-08-24T10:30:00Z'
-                      updated_at:
-                        type: string
-                        nullable: true
-                        description: ISO 8601 timestamp of when the guardrail was last updated
-                        example: '2025-08-24T15:45:00Z'
-                    required:
-                      - id
-                      - name
-                      - created_at
-                    example:
-                      id: 550e8400-e29b-41d4-a716-446655440000
-                      name: Production Guardrail
-                      description: Guardrail for production environment
-                      limit_usd: 100
-                      reset_interval: monthly
-                      allowed_providers:
-                        - openai
-                        - anthropic
-                        - google
-                      allowed_models: null
-                      enforce_zdr: false
-                      created_at: '2025-08-24T10:30:00Z'
-                      updated_at: '2025-08-24T15:45:00Z'
-                    description: The guardrail
-                required:
-                  - data
-                example:
-                  data:
-                    id: 550e8400-e29b-41d4-a716-446655440000
-                    name: Production Guardrail
-                    description: Guardrail for production environment
-                    limit_usd: 100
-                    reset_interval: monthly
-                    allowed_providers:
-                      - openai
-                      - anthropic
-                      - google
-                    allowed_models: null
-                    enforce_zdr: false
-                    created_at: '2025-08-24T10:30:00Z'
-                    updated_at: '2025-08-24T15:45:00Z'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Not Found - Guardrail does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-    patch:
-      operationId: updateGuardrail
-      x-speakeasy-name-override: update
-      tags:
-        - Guardrails
-      summary: Update a guardrail
-      description: Update an existing guardrail. [Provisioning key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail to update
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail to update
-          name: id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                  maxLength: 200
-                  description: New name for the guardrail
-                  example: Updated Guardrail Name
-                description:
-                  type: string
-                  nullable: true
-                  maxLength: 1000
-                  description: New description for the guardrail
-                  example: Updated description
-                limit_usd:
-                  type: number
-                  nullable: true
-                  minimum: 0
-                  exclusiveMinimum: true
-                  description: New spending limit in USD
-                  example: 75
-                reset_interval:
-                  type: string
-                  nullable: true
-                  enum:
-                    - daily
-                    - weekly
-                    - monthly
-                  description: Interval at which the limit resets (daily, weekly, monthly)
-                  example: monthly
-                allowed_providers:
-                  type: array
-                  nullable: true
-                  items:
-                    type: string
-                  minItems: 1
-                  description: New list of allowed provider IDs
-                  example:
-                    - openai
-                    - anthropic
-                    - deepseek
-                allowed_models:
-                  type: array
-                  nullable: true
-                  items:
-                    type: string
-                  minItems: 1
-                  description: Array of model identifiers (slug or canonical_slug accepted)
-                  example:
-                    - openai/gpt-5.2
-                enforce_zdr:
-                  type: boolean
-                  nullable: true
-                  description: Whether to enforce zero data retention
-                  example: true
-              example:
-                name: Updated Guardrail Name
-                description: Updated description
-                limit_usd: 75
-                reset_interval: weekly
-        required: true
-      responses:
-        '200':
-          description: Guardrail updated successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        format: uuid
-                        description: Unique identifier for the guardrail
-                        example: 550e8400-e29b-41d4-a716-446655440000
-                      name:
-                        type: string
-                        description: Name of the guardrail
-                        example: Production Guardrail
-                      description:
-                        type: string
-                        nullable: true
-                        description: Description of the guardrail
-                        example: Guardrail for production environment
-                      limit_usd:
-                        type: number
-                        nullable: true
-                        minimum: 0
-                        exclusiveMinimum: true
-                        description: Spending limit in USD
-                        example: 100
-                      reset_interval:
-                        type: string
-                        nullable: true
-                        enum:
-                          - daily
-                          - weekly
-                          - monthly
-                        description: Interval at which the limit resets (daily, weekly, monthly)
-                        example: monthly
-                      allowed_providers:
-                        type: array
-                        nullable: true
-                        items:
-                          type: string
-                        description: List of allowed provider IDs
-                        example:
-                          - openai
-                          - anthropic
-                          - google
-                      allowed_models:
-                        type: array
-                        nullable: true
-                        items:
-                          type: string
-                        description: Array of model canonical_slugs (immutable identifiers)
-                        example:
-                          - openai/gpt-5.2-20251211
-                          - anthropic/claude-4.5-opus-20251124
-                          - deepseek/deepseek-r1-0528:free
-                      enforce_zdr:
-                        type: boolean
-                        nullable: true
-                        description: Whether to enforce zero data retention
-                        example: false
-                      created_at:
-                        type: string
-                        description: ISO 8601 timestamp of when the guardrail was created
-                        example: '2025-08-24T10:30:00Z'
-                      updated_at:
-                        type: string
-                        nullable: true
-                        description: ISO 8601 timestamp of when the guardrail was last updated
-                        example: '2025-08-24T15:45:00Z'
-                    required:
-                      - id
-                      - name
-                      - created_at
-                    example:
-                      id: 550e8400-e29b-41d4-a716-446655440000
-                      name: Production Guardrail
-                      description: Guardrail for production environment
-                      limit_usd: 100
-                      reset_interval: monthly
-                      allowed_providers:
-                        - openai
-                        - anthropic
-                        - google
-                      allowed_models: null
-                      enforce_zdr: false
-                      created_at: '2025-08-24T10:30:00Z'
-                      updated_at: '2025-08-24T15:45:00Z'
-                    description: The updated guardrail
-                required:
-                  - data
-                example:
-                  data:
-                    id: 550e8400-e29b-41d4-a716-446655440000
-                    name: Updated Guardrail Name
-                    description: Updated description
-                    limit_usd: 75
-                    reset_interval: weekly
-                    allowed_providers:
-                      - openai
-                    allowed_models: null
-                    enforce_zdr: true
-                    created_at: '2025-08-24T10:30:00Z'
-                    updated_at: '2025-08-24T16:00:00Z'
-        '400':
-          description: Bad Request - Invalid request parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Not Found - Guardrail does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-    delete:
-      operationId: deleteGuardrail
-      x-speakeasy-name-override: delete
-      tags:
-        - Guardrails
-      summary: Delete a guardrail
-      description: Delete an existing guardrail. [Provisioning key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail to delete
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail to delete
-          name: id
-          in: path
-      responses:
-        '200':
-          description: Guardrail deleted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  deleted:
-                    type: boolean
-                    const: true
-                    description: Confirmation that the guardrail was deleted
-                    example: true
-                required:
-                  - deleted
-                example:
-                  deleted: true
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Not Found - Guardrail does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /guardrails/assignments/keys:
-    get:
-      operationId: listKeyAssignments
-      x-speakeasy-name-override: listKeyAssignments
-      tags:
-        - Guardrails
-      summary: List all key assignments
-      description: >-
-        List all API key guardrail assignments for the authenticated user. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            description: Number of records to skip for pagination
-            example: '0'
-          required: false
-          description: Number of records to skip for pagination
-          name: offset
-          in: query
-        - schema:
-            type: string
-            description: Maximum number of records to return (max 100)
-            example: '50'
-          required: false
-          description: Maximum number of records to return (max 100)
-          name: limit
-          in: query
-      responses:
-        '200':
-          description: List of key assignments
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          format: uuid
-                          description: Unique identifier for the assignment
-                          example: 550e8400-e29b-41d4-a716-446655440000
-                        key_hash:
-                          type: string
-                          description: Hash of the assigned API key
-                          example: c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93
-                        guardrail_id:
-                          type: string
-                          format: uuid
-                          description: ID of the guardrail
-                          example: 550e8400-e29b-41d4-a716-446655440001
-                        key_name:
-                          type: string
-                          description: Name of the API key
-                          example: Production Key
-                        key_label:
-                          type: string
-                          description: Label of the API key
-                          example: prod-key
-                        assigned_by:
-                          type: string
-                          nullable: true
-                          description: User ID of who made the assignment
-                          example: user_abc123
-                        created_at:
-                          type: string
-                          description: ISO 8601 timestamp of when the assignment was created
-                          example: '2025-08-24T10:30:00Z'
-                      required:
-                        - id
-                        - key_hash
-                        - guardrail_id
-                        - key_name
-                        - key_label
-                        - assigned_by
-                        - created_at
-                    description: List of key assignments
-                  total_count:
-                    type: number
-                    description: Total number of key assignments for this guardrail
-                    example: 25
-                required:
-                  - data
-                  - total_count
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /guardrails/assignments/members:
-    get:
-      operationId: listMemberAssignments
-      x-speakeasy-name-override: listMemberAssignments
-      tags:
-        - Guardrails
-      summary: List all member assignments
-      description: >-
-        List all organization member guardrail assignments for the authenticated user. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            description: Number of records to skip for pagination
-            example: '0'
-          required: false
-          description: Number of records to skip for pagination
-          name: offset
-          in: query
-        - schema:
-            type: string
-            description: Maximum number of records to return (max 100)
-            example: '50'
-          required: false
-          description: Maximum number of records to return (max 100)
-          name: limit
-          in: query
-      responses:
-        '200':
-          description: List of member assignments
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          format: uuid
-                          description: Unique identifier for the assignment
-                          example: 550e8400-e29b-41d4-a716-446655440000
-                        user_id:
-                          type: string
-                          description: Clerk user ID of the assigned member
-                          example: user_abc123
-                        organization_id:
-                          type: string
-                          description: Organization ID
-                          example: org_xyz789
-                        guardrail_id:
-                          type: string
-                          format: uuid
-                          description: ID of the guardrail
-                          example: 550e8400-e29b-41d4-a716-446655440001
-                        assigned_by:
-                          type: string
-                          nullable: true
-                          description: User ID of who made the assignment
-                          example: user_abc123
-                        created_at:
-                          type: string
-                          description: ISO 8601 timestamp of when the assignment was created
-                          example: '2025-08-24T10:30:00Z'
-                      required:
-                        - id
-                        - user_id
-                        - organization_id
-                        - guardrail_id
-                        - assigned_by
-                        - created_at
-                    description: List of member assignments
-                  total_count:
-                    type: number
-                    description: Total number of member assignments
-                    example: 10
-                required:
-                  - data
-                  - total_count
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /guardrails/{id}/assignments/keys:
-    get:
-      operationId: listGuardrailKeyAssignments
-      x-speakeasy-name-override: listGuardrailKeyAssignments
-      tags:
-        - Guardrails
-      summary: List key assignments for a guardrail
-      description: >-
-        List all API key assignments for a specific guardrail. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail
-          name: id
-          in: path
-        - schema:
-            type: string
-            description: Number of records to skip for pagination
-            example: '0'
-          required: false
-          description: Number of records to skip for pagination
-          name: offset
-          in: query
-        - schema:
-            type: string
-            description: Maximum number of records to return (max 100)
-            example: '50'
-          required: false
-          description: Maximum number of records to return (max 100)
-          name: limit
-          in: query
-      responses:
-        '200':
-          description: List of key assignments
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          format: uuid
-                          description: Unique identifier for the assignment
-                          example: 550e8400-e29b-41d4-a716-446655440000
-                        key_hash:
-                          type: string
-                          description: Hash of the assigned API key
-                          example: c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93
-                        guardrail_id:
-                          type: string
-                          format: uuid
-                          description: ID of the guardrail
-                          example: 550e8400-e29b-41d4-a716-446655440001
-                        key_name:
-                          type: string
-                          description: Name of the API key
-                          example: Production Key
-                        key_label:
-                          type: string
-                          description: Label of the API key
-                          example: prod-key
-                        assigned_by:
-                          type: string
-                          nullable: true
-                          description: User ID of who made the assignment
-                          example: user_abc123
-                        created_at:
-                          type: string
-                          description: ISO 8601 timestamp of when the assignment was created
-                          example: '2025-08-24T10:30:00Z'
-                      required:
-                        - id
-                        - key_hash
-                        - guardrail_id
-                        - key_name
-                        - key_label
-                        - assigned_by
-                        - created_at
-                    description: List of key assignments
-                  total_count:
-                    type: number
-                    description: Total number of key assignments for this guardrail
-                    example: 25
-                required:
-                  - data
-                  - total_count
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Guardrail not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-    post:
-      operationId: bulkAssignKeysToGuardrail
-      x-speakeasy-name-override: bulkAssignKeys
-      tags:
-        - Guardrails
-      summary: Bulk assign keys to a guardrail
-      description: >-
-        Assign multiple API keys to a specific guardrail. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail
-          name: id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                key_hashes:
-                  type: array
-                  items:
-                    type: string
-                    minLength: 1
-                  minItems: 1
-                  description: Array of API key hashes to assign to the guardrail
-                  example:
-                    - c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93
-              required:
-                - key_hashes
-        required: true
-      responses:
-        '200':
-          description: Assignment result
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  assigned_count:
-                    type: number
-                    description: Number of keys successfully assigned
-                    example: 3
-                required:
-                  - assigned_count
-        '400':
-          description: Bad Request - Invalid input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Guardrail not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /guardrails/{id}/assignments/members:
-    get:
-      operationId: listGuardrailMemberAssignments
-      x-speakeasy-name-override: listGuardrailMemberAssignments
-      tags:
-        - Guardrails
-      summary: List member assignments for a guardrail
-      description: >-
-        List all organization member assignments for a specific guardrail. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail
-          name: id
-          in: path
-        - schema:
-            type: string
-            description: Number of records to skip for pagination
-            example: '0'
-          required: false
-          description: Number of records to skip for pagination
-          name: offset
-          in: query
-        - schema:
-            type: string
-            description: Maximum number of records to return (max 100)
-            example: '50'
-          required: false
-          description: Maximum number of records to return (max 100)
-          name: limit
-          in: query
-      responses:
-        '200':
-          description: List of member assignments
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          format: uuid
-                          description: Unique identifier for the assignment
-                          example: 550e8400-e29b-41d4-a716-446655440000
-                        user_id:
-                          type: string
-                          description: Clerk user ID of the assigned member
-                          example: user_abc123
-                        organization_id:
-                          type: string
-                          description: Organization ID
-                          example: org_xyz789
-                        guardrail_id:
-                          type: string
-                          format: uuid
-                          description: ID of the guardrail
-                          example: 550e8400-e29b-41d4-a716-446655440001
-                        assigned_by:
-                          type: string
-                          nullable: true
-                          description: User ID of who made the assignment
-                          example: user_abc123
-                        created_at:
-                          type: string
-                          description: ISO 8601 timestamp of when the assignment was created
-                          example: '2025-08-24T10:30:00Z'
-                      required:
-                        - id
-                        - user_id
-                        - organization_id
-                        - guardrail_id
-                        - assigned_by
-                        - created_at
-                    description: List of member assignments
-                  total_count:
-                    type: number
-                    description: Total number of member assignments
-                    example: 10
-                required:
-                  - data
-                  - total_count
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Guardrail not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-    post:
-      operationId: bulkAssignMembersToGuardrail
-      x-speakeasy-name-override: bulkAssignMembers
-      tags:
-        - Guardrails
-      summary: Bulk assign members to a guardrail
-      description: >-
-        Assign multiple organization members to a specific guardrail. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail
-          name: id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                member_user_ids:
-                  type: array
-                  items:
-                    type: string
-                    minLength: 1
-                  minItems: 1
-                  description: Array of member user IDs to assign to the guardrail
-                  example:
-                    - user_abc123
-                    - user_def456
-              required:
-                - member_user_ids
-        required: true
-      responses:
-        '200':
-          description: Assignment result
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  assigned_count:
-                    type: number
-                    description: Number of members successfully assigned
-                    example: 2
-                required:
-                  - assigned_count
-        '400':
-          description: Bad Request - Invalid input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Guardrail not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /guardrails/{id}/assignments/keys/remove:
-    post:
-      operationId: bulkUnassignKeysFromGuardrail
-      x-speakeasy-name-override: bulkUnassignKeys
-      tags:
-        - Guardrails
-      summary: Bulk unassign keys from a guardrail
-      description: >-
-        Unassign multiple API keys from a specific guardrail. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail
-          name: id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                key_hashes:
-                  type: array
-                  items:
-                    type: string
-                    minLength: 1
-                  minItems: 1
-                  description: Array of API key hashes to unassign from the guardrail
-                  example:
-                    - c56454edb818d6b14bc0d61c46025f1450b0f4012d12304ab40aacb519fcbc93
-              required:
-                - key_hashes
-        required: true
-      responses:
-        '200':
-          description: Unassignment result
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  unassigned_count:
-                    type: number
-                    description: Number of keys successfully unassigned
-                    example: 3
-                required:
-                  - unassigned_count
-        '400':
-          description: Bad Request - Invalid input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Guardrail not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /guardrails/{id}/assignments/members/remove:
-    post:
-      operationId: bulkUnassignMembersFromGuardrail
-      x-speakeasy-name-override: bulkUnassignMembers
-      tags:
-        - Guardrails
-      summary: Bulk unassign members from a guardrail
-      description: >-
-        Unassign multiple organization members from a specific guardrail. [Provisioning
-        key](/docs/guides/overview/auth/provisioning-api-keys) required.
-      parameters:
-        - schema:
-            type: string
-            format: uuid
-            description: The unique identifier of the guardrail
-            example: 550e8400-e29b-41d4-a716-446655440000
-          required: true
-          description: The unique identifier of the guardrail
-          name: id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                member_user_ids:
-                  type: array
-                  items:
-                    type: string
-                    minLength: 1
-                  minItems: 1
-                  description: Array of member user IDs to unassign from the guardrail
-                  example:
-                    - user_abc123
-                    - user_def456
-              required:
-                - member_user_ids
-        required: true
-      responses:
-        '200':
-          description: Unassignment result
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  unassigned_count:
-                    type: number
-                    description: Number of members successfully unassigned
-                    example: 2
-                required:
-                  - unassigned_count
-        '400':
-          description: Bad Request - Invalid input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Missing or invalid authentication
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '404':
-          description: Guardrail not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundResponse'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /key:
-    get:
-      operationId: getCurrentKey
-      x-speakeasy-name-override: getCurrentKeyMetadata
-      tags:
-        - API Keys
-      summary: Get current API key
-      description: Get information on the API key associated with the current authentication session
-      responses:
-        '200':
-          description: API key details
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      label:
-                        type: string
-                        description: Human-readable label for the API key
-                        example: sk-or-v1-0e6...1c96
-                      limit:
-                        type: number
-                        nullable: true
-                        description: Spending limit for the API key in USD
-                        example: 100
-                      usage:
-                        type: number
-                        description: Total OpenRouter credit usage (in USD) for the API key
-                        example: 25.5
-                      usage_daily:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC day
-                        example: 25.5
-                      usage_weekly:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC week (Monday-Sunday)
-                        example: 25.5
-                      usage_monthly:
-                        type: number
-                        description: OpenRouter credit usage (in USD) for the current UTC month
-                        example: 25.5
-                      byok_usage:
-                        type: number
-                        description: Total external BYOK usage (in USD) for the API key
-                        example: 17.38
-                      byok_usage_daily:
-                        type: number
-                        description: External BYOK usage (in USD) for the current UTC day
-                        example: 17.38
-                      byok_usage_weekly:
-                        type: number
-                        description: External BYOK usage (in USD) for the current UTC week (Monday-Sunday)
-                        example: 17.38
-                      byok_usage_monthly:
-                        type: number
-                        description: External BYOK usage (in USD) for current UTC month
-                        example: 17.38
-                      is_free_tier:
-                        type: boolean
-                        description: Whether this is a free tier API key
-                        example: false
-                      is_provisioning_key:
-                        type: boolean
-                        description: Whether this is a provisioning key
-                        example: false
-                      limit_remaining:
-                        type: number
-                        nullable: true
-                        description: Remaining spending limit in USD
-                        example: 74.5
-                      limit_reset:
-                        type: string
-                        nullable: true
-                        description: Type of limit reset for the API key
-                        example: monthly
-                      include_byok_in_limit:
-                        type: boolean
-                        description: Whether to include external BYOK usage in the credit limit
-                        example: false
-                      expires_at:
-                        type: string
-                        nullable: true
-                        format: date-time
-                        description: ISO 8601 UTC timestamp when the API key expires, or null if no expiration
-                        example: '2027-12-31T23:59:59Z'
-                      rate_limit:
-                        type: object
-                        properties:
-                          requests:
-                            type: number
-                            description: Number of requests allowed per interval
-                            example: 1000
-                          interval:
-                            type: string
-                            description: Rate limit interval
-                            example: 1h
-                          note:
-                            type: string
-                            description: Note about the rate limit
-                            example: This field is deprecated and safe to ignore.
-                        required:
-                          - requests
-                          - interval
-                          - note
-                        description: Legacy rate limit information about a key. Will always return -1.
-                        deprecated: true
-                        example:
-                          requests: 1000
-                          interval: 1h
-                          note: This field is deprecated and safe to ignore.
-                    required:
-                      - label
-                      - limit
-                      - usage
-                      - usage_daily
-                      - usage_weekly
-                      - usage_monthly
-                      - byok_usage
-                      - byok_usage_daily
-                      - byok_usage_weekly
-                      - byok_usage_monthly
-                      - is_free_tier
-                      - is_provisioning_key
-                      - limit_remaining
-                      - limit_reset
-                      - include_byok_in_limit
-                      - rate_limit
-                    description: Current API key information
-                    example:
-                      label: sk-or-v1-au7...890
-                      limit: 100
-                      usage: 25.5
-                      usage_daily: 25.5
-                      usage_weekly: 25.5
-                      usage_monthly: 25.5
-                      byok_usage: 17.38
-                      byok_usage_daily: 17.38
-                      byok_usage_weekly: 17.38
-                      byok_usage_monthly: 17.38
-                      is_free_tier: false
-                      is_provisioning_key: false
-                      limit_remaining: 74.5
-                      limit_reset: monthly
-                      include_byok_in_limit: false
-                      expires_at: '2027-12-31T23:59:59Z'
-                      rate_limit:
-                        requests: 1000
-                        interval: 1h
-                        note: This field is deprecated and safe to ignore.
-                required:
-                  - data
-                example:
-                  data:
-                    label: sk-or-v1-au7...890
-                    limit: 100
-                    usage: 25.5
-                    usage_daily: 25.5
-                    usage_weekly: 25.5
-                    usage_monthly: 25.5
-                    byok_usage: 17.38
-                    byok_usage_daily: 17.38
-                    byok_usage_weekly: 17.38
-                    byok_usage_monthly: 17.38
-                    is_free_tier: false
-                    is_provisioning_key: false
-                    limit_remaining: 74.5
-                    limit_reset: monthly
-                    include_byok_in_limit: false
-                    expires_at: '2027-12-31T23:59:59Z'
-                    rate_limit:
-                      requests: 1000
-                      interval: 1h
-                      note: This field is deprecated and safe to ignore.
-        '401':
-          description: Unauthorized - Authentication required or invalid credentials
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '500':
-          description: Internal Server Error - Unexpected server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /auth/keys:
-    post:
-      operationId: exchangeAuthCodeForAPIKey
-      tags:
-        - OAuth
-      summary: Exchange authorization code for API key
-      description: Exchange an authorization code from the PKCE flow for a user-controlled API key
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                code:
-                  type: string
-                  description: The authorization code received from the OAuth redirect
-                  example: auth_code_abc123def456
-                code_verifier:
-                  type: string
-                  description: The code verifier if code_challenge was used in the authorization request
-                  example: dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
-                code_challenge_method:
-                  type: string
-                  nullable: true
-                  enum:
-                    - S256
-                    - plain
-                  description: The method used to generate the code challenge
-                  example: S256
-              required:
-                - code
-              example:
-                code: auth_code_abc123def456
-                code_verifier: dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
-                code_challenge_method: S256
-        required: true
-      responses:
-        '200':
-          description: Successfully exchanged code for an API key
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  key:
-                    type: string
-                    description: The API key to use for OpenRouter requests
-                    example: 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
-                  user_id:
-                    type: string
-                    nullable: true
-                    description: User ID associated with the API key
-                    example: user_2yOPcMpKoQhcd4bVgSMlELRaIah
-                required:
-                  - key
-                  - user_id
-                example:
-                  key: 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
-                  user_id: user_2yOPcMpKoQhcd4bVgSMlELRaIah
-        '400':
-          description: Bad Request - Invalid request parameters or malformed input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '403':
-          description: Forbidden - Authentication successful but insufficient permissions
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-        '500':
-          description: Internal Server Error - Unexpected server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-  /auth/keys/code:
-    post:
-      x-speakeasy-name-override: createAuthCode
-      tags:
-        - OAuth
-      summary: Create authorization code
-      description: Create an authorization code for the PKCE flow to generate a user-controlled API key
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                callback_url:
-                  type: string
-                  format: uri
-                  description: >-
-                    The callback URL to redirect to after authorization. Note, only https URLs on ports 443 and 3000 are
-                    allowed.
-                  example: https://myapp.com/auth/callback
-                code_challenge:
-                  type: string
-                  description: PKCE code challenge for enhanced security
-                  example: E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
-                code_challenge_method:
-                  type: string
-                  enum:
-                    - S256
-                    - plain
-                  description: The method used to generate the code challenge
-                  example: S256
-                limit:
-                  type: number
-                  description: Credit limit for the API key to be created
-                  example: 100
-                expires_at:
-                  type: string
-                  nullable: true
-                  format: date-time
-                  description: Optional expiration time for the API key to be created
-              required:
-                - callback_url
-              example:
-                callback_url: https://myapp.com/auth/callback
-                code_challenge: E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
-                code_challenge_method: S256
-                limit: 100
-        required: true
-      responses:
-        '200':
-          description: Successfully created authorization code
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        description: The authorization code ID to use in the exchange request
-                        example: auth_code_xyz789
-                      app_id:
-                        type: number
-                        description: The application ID associated with this auth code
-                        example: 12345
-                      created_at:
-                        type: string
-                        description: ISO 8601 timestamp of when the auth code was created
-                        example: '2025-08-24T10:30:00Z'
-                    required:
-                      - id
-                      - app_id
-                      - created_at
-                    description: Auth code data
-                    example:
-                      id: auth_code_xyz789
-                      app_id: 12345
-                      created_at: '2025-08-24T10:30:00Z'
-                required:
-                  - data
-        '400':
-          description: Bad Request - Invalid request parameters or malformed input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequestResponse'
-        '401':
-          description: Unauthorized - Authentication required or invalid credentials
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UnauthorizedResponse'
-        '500':
-          description: Internal Server Error - Unexpected server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InternalServerResponse'
-      operationId: createAuthKeysCode
-  /chat/completions:
-    post:
-      summary: Create a chat completion
-      operationId: sendChatCompletionRequest
-      x-speakeasy-group: chat
-      x-speakeasy-name-override: send
-      x-speakeasy-stream-request-field: stream
-      description: >-
-        Sends a request for a model response for the given chat conversation. Supports both streaming and non-streaming
-        modes.
-      tags:
-        - Chat
-      requestBody:
-        required: true
-        description: Chat completion request parameters
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ChatGenerationParams'
-      responses:
-        '200':
-          description: Successful chat completion response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChatResponse'
-                description: Chat completion response
-            text/event-stream:
-              x-speakeasy-sse-sentinel: '[DONE]'
-              schema:
-                $ref: '#/components/schemas/ChatStreamingResponseChunk'
-        '400':
-          description: Bad request - invalid parameters
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChatError'
-        '401':
-          description: Unauthorized - invalid API key
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChatError'
-        '429':
-          description: Too many requests - rate limit exceeded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChatError'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChatError'
-servers:
-  - url: https://openrouter.ai/api/v1
-    description: Production server
-    x-speakeasy-server-id: production
-security:
-  - apiKey: []
-externalDocs:
-  description: OpenRouter Documentation
-  url: https://openrouter.ai/docs
 tags:
   - name: API Keys
     description: API key management endpoints
   - name: Analytics
     description: Analytics and usage endpoints
+  - name: Anthropic Messages
+    description: Anthropic Messages endpoints
   - name: Chat
     description: Chat completion endpoints
   - name: Credits
@@ -13597,10 +19524,10 @@ tags:
     description: Model information endpoints
   - name: OAuth
     description: OAuth authentication endpoints
+  - name: Organization
+    description: Organization endpoints
   - name: Providers
     description: Provider information endpoints
-  - name: anthropic.messages
-    description: anthropic.messages endpoints
   - name: beta.responses
     description: beta.responses endpoints
 x-fern-base-path: /


### PR DESCRIPTION
## OpenAPI Spec Update

Manual update of the OpenAPI specification from the monorepo to bring the Go SDK in sync.

This replaces `.speakeasy/in.openapi.yaml` with the latest spec from `projects/docs/fern/openapi/openapi.yaml` in the monorepo.