### PR TITLE
ci: add SDK regeneration workflow

### DIFF
--- a/.github/workflows/regenerate-sdk.yaml
+++ b/.github/workflows/regenerate-sdk.yaml
@@ -1,0 +1,17 @@
+name: Regenerate SDK
+
+on:
+  pull_request:
+    paths:
+      - ".speakeasy/in.openapi.yaml"
+
+jobs:
+  regenerate:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    with:
+      speakeasy_version: "1.680.0"
+      force: true
+      mode: direct
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that triggers when a PR modifies `.speakeasy/in.openapi.yaml`
- Uses the official Speakeasy reusable workflow (`workflow-executor.yaml@v15`) in direct mode to regenerate the Go SDK and commit changes back to the PR branch
- Pins Speakeasy CLI to v1.680.0 (matching `.speakeasy/workflow.yaml`)

## Test plan
- [ ] Verify `SPEAKEASY_API_KEY` secret is available at the org level
- [ ] Open a test PR that modifies `.speakeasy/in.openapi.yaml` and confirm the action runs and commits regenerated SDK code