### PR TITLE
test: trigger SDK regeneration workflow

### DIFF
--- a/.github/workflows/regenerate-sdk.yaml
+++ b/.github/workflows/regenerate-sdk.yaml
@@ -9,7 +9,7 @@ jobs:
   regenerate:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
-      speakeasy_version: "1.680.0"
+      speakeasy_version: "1.761.1"
       force: true
       mode: direct
     secrets:

--- a/.github/workflows/regenerate-sdk.yaml
+++ b/.github/workflows/regenerate-sdk.yaml
@@ -13,5 +13,5 @@ jobs:
       force: true
       mode: direct
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      github_access_token: ${{ secrets.SDK_MERGE_PAT }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -1,17 +1,20 @@
-name: Regenerate SDK
+name: Generate SDK
 
 on:
-  pull_request:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
     paths:
       - ".speakeasy/in.openapi.yaml"
 
 jobs:
-  regenerate:
+  generate:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
       speakeasy_version: "1.761.1"
       force: true
-      mode: direct
+      mode: pr
     secrets:
       github_access_token: ${{ secrets.SDK_MERGE_PAT }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -1,0 +1,17 @@
+name: Publish SDK
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "RELEASES.md"
+
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    with:
+      target: openrouter
+    secrets:
+      github_access_token: ${{ secrets.SDK_MERGE_PAT }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: OpenRouter API
   version: 1.0.0
-  description: OpenAI-compatible API with additional OpenRouter features
+  description: OpenAI-compatible API with additional OpenRouter features.
   contact:
     name: OpenRouter Support
     url: https://openrouter.ai/docs

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.680.0
+speakeasyVersion: 1.761.1
 sources:
   OpenRouter API:
     inputs:


### PR DESCRIPTION
Trivial description punctuation change to `.speakeasy/in.openapi.yaml` to test the new regeneration workflow from #3.

Safe to close after verifying the action runs.