### PR TITLE
fix: add generic overlay to remove redundant allOf inline enums

### DIFF
--- a/.speakeasy/overlays/allof-simplify.overlay.yaml
+++ b/.speakeasy/overlays/allof-simplify.overlay.yaml
@@ -1,0 +1,11 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Simplify redundant allOf inline schemas
+  version: 0.0.0
+actions:
+  - target: "$..allOf[?@.enum && !@['$ref']]"
+    description: >
+      Remove inline enum definitions that duplicate a $ref enum in the same
+      allOf. These are artifacts from zod-openapi .extend() serialization.
+    remove: true

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -8,6 +8,7 @@ sources:
       - location: .speakeasy/overlays/open-enums.overlay.yaml
       - location: .speakeasy/overlays/remove-rss-responses.overlay.yaml
       - location: .speakeasy/overlays/add-headers.overlay.yaml
+      - location: .speakeasy/overlays/allof-simplify.overlay.yaml
     output: .speakeasy/out.openapi.yaml
     registry:
       location: registry.speakeasyapi.dev/openrouter/sdk/open-router-chat-completions-api


### PR DESCRIPTION
## Summary

- Add `allof-simplify.overlay.yaml` with a generic JSONPath filter: `$..allOf[?@.enum && !@['$ref']]`
- Removes inline enum constraints that duplicate a `$ref` enum in the same `allOf`
- These are artifacts from `zod-openapi`'s `.extend()` serialization
- Reduces Speakeasy `duplicate-inline-schemas` warnings by ~8 (all allOf+enum patterns)
- Generic — automatically handles any new schemas that produce this pattern

## Test plan
- [x] `speakeasy overlay validate` passes
- [x] `speakeasy overlay apply` successfully removes redundant enums
- [x] `speakeasy lint` confirms reduction in duplicate warnings