### PR TITLE
chore: set forwardCompatibleUnionsByDefault to tagged-only

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -46,7 +46,7 @@ go:
   flattenGlobalSecurity: true
   flatteningOrder: parameters-first
   forwardCompatibleEnumsByDefault: true
-  forwardCompatibleUnionsByDefault: "false"
+  forwardCompatibleUnionsByDefault: "tagged-only"
   imports:
     option: openapi
     paths:


### PR DESCRIPTION
## Summary

- Updates `.speakeasy/gen.yaml` to set `forwardCompatibleUnionsByDefault` from `"false"` to `"tagged-only"` in the Go SDK generation config.

This configures the Speakeasy code generator to use tagged-only forward compatible unions, which ensures that only unions with explicit discriminator tags get forward-compatible deserialization behavior while leaving untagged unions with strict typing.