### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -15100,7 +15100,7 @@ paths:
             audio/*:
               schema:
                 description: >-
-                  Raw audio bytestream. Content-Type varies by requested format (audio/mpeg for mp3, audio/L16 for pcm —
+                  Raw audio bytestream. Content-Type varies by requested format (audio/mpeg for mp3, audio/pcm for pcm —
                   16-bit little-endian).
                 example: <binary audio data>
                 format: binary


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow. If CI passes, it will be auto-merged.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/24893418540)