### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -21687,7 +21687,6 @@ tags:
     name: Workspaces
   - description: beta.responses endpoints
     name: beta.responses
-x-fern-base-path: /
 x-retry-strategy:
   initialDelay: 500
   maxAttempts: 3


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/25340339106)