### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -5381,11 +5381,11 @@ components:
           minLength: 1
           type: string
         slug:
-          description: URL-friendly slug (lowercase alphanumeric and hyphens only)
+          description: URL-friendly slug (lowercase alphanumeric segments separated by single hyphens, no leading/trailing hyphens)
           example: production
           maxLength: 50
           minLength: 1
-          pattern: ^[a-z0-9-]+$
+          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
           type: string
       required:
         - name
@@ -14663,11 +14663,13 @@ components:
           minLength: 1
           type: string
         slug:
-          description: New URL-friendly slug
+          description: >-
+            New URL-friendly slug (lowercase alphanumeric segments separated by single hyphens, no leading/trailing
+            hyphens)
           example: updated-workspace
           maxLength: 50
           minLength: 1
-          pattern: ^[a-z0-9-]+$
+          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
           type: string
       type: object
     UpdateWorkspaceResponse:


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/25709609883)