### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -10264,7 +10264,7 @@ components:
                 input_tokens: 100
                 output_tokens: 50
                 server_tool_use: null
-                service_tier: standard
+                service_tier: default
           type: object
       description: Non-streaming response from the Anthropic Messages API with OpenRouter extensions
       example:
@@ -10288,7 +10288,7 @@ components:
           input_tokens: 12
           output_tokens: 15
           server_tool_use: null
-          service_tier: standard
+          service_tier: default
     MessagesStartEvent:
       description: Event sent at the start of a streaming message
       example:
@@ -10465,7 +10465,7 @@ components:
                 input_tokens: 100
                 output_tokens: 50
                 server_tool_use: null
-                service_tier: standard
+                service_tier: default
           required:
             - id
             - type


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/26319021565)