### PR TITLE
ci: switch SDK generation from PR mode to direct mode

### DIFF
--- a/.github/workflows/sdk-generation.yaml
+++ b/.github/workflows/sdk-generation.yaml
@@ -14,7 +14,7 @@ jobs:
     with:
       speakeasy_version: "1.761.1"
       force: true
-      mode: pr
+      mode: direct
     secrets:
-      github_access_token: ${{ secrets.SDK_MERGE_PAT }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
## Summary

Switches SDK generation from `mode: pr` to `mode: direct`. Same issue as OpenRouterTeam/python-sdk#315: OpenAPI spec updates land on `main` automatically, the generator opens a rolling PR, and nothing ever merges it.

Current state of this repo:

- Generation PR #163 has been open since **Apr 22** (still updated by the bot daily)
- Last release was **v0.4.1 on Apr 21** — no SDK changes have shipped in ~7 weeks despite daily spec updates

With `mode: direct`, the regenerated SDK commits straight to `main`, matching the typescript-sdk pattern. Publishing is triggered separately via `workflow_dispatch` on the Publish workflow when ready.

## Test plan

- [ ] After merge, wait for the next automated spec update PR to land (or trigger via `workflow_dispatch`)
- [ ] Verify a regeneration commit lands on `main`
- [ ] Close stale generation PR #163 once a direct-mode regeneration has landed
