### PR TITLE
chore: update OpenAPI spec from monorepo

### DIFF
--- a/.speakeasy/in.openapi.yaml
+++ b/.speakeasy/in.openapi.yaml
@@ -17358,8 +17358,8 @@ components:
       type: string
     ProviderOptions:
       description: >-
-        Provider-specific options keyed by provider slug. The options for the matched provider are spread into the
-        upstream request body.
+        Provider-specific options keyed by provider slug. Only options for the matched provider are forwarded; the rest
+        are ignored. Unrecognized keys are silently dropped.
       example:
         openai:
           max_tokens: 1000


### PR DESCRIPTION
## OpenAPI Spec Update

Automated update of the OpenAPI specification from the monorepo release.

This PR was created by the SDK release workflow and will be merged automatically.

[Workflow run](https://github.com/OpenRouterTeam/openrouter-web/actions/runs/27601297802)