### PR TITLE
docs+ci: bump pinned version to v0.5.2 and fix release-time example bump

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -80,7 +80,10 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add examples go.work.sum README.md OVERVIEW.md
+          # Stage every file bump-examples.sh may touch (example go.mod/go.sum,
+          # workspace sum, and all docs in its DOCS list incl. doc.go +
+          # example_test.go). Use -A so newly-tidied go.sum entries are included.
+          git add -A
           git commit -m "$(cat <<EOF
           chore: bump examples to SDK $(awk '/^  releaseVersion: / { print "v" $2; exit }' .speakeasy/gen.lock)
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -117,7 +117,7 @@ go get github.com/OpenRouterTeam/go-sdk
 For beta releases, pin an explicit version:
 
 ```bash
-go get github.com/OpenRouterTeam/go-sdk@v0.5.0
+go get github.com/OpenRouterTeam/go-sdk@v0.5.2
 ```
 
 **Requirements:** Go 1.25 or higher

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To learn more, see the [API Reference](https://openrouter.ai/docs/sdks/go/api-re
 > This SDK is in **beta**. Pin to a specific version to avoid unexpected breaking changes:
 >
 > ```bash
-> go get github.com/OpenRouterTeam/go-sdk@v0.5.0
+> go get github.com/OpenRouterTeam/go-sdk@v0.5.2
 > ```
 
 <!-- No Summary [summary] -->

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ provider selection, and unified billing.
 
 This SDK is in beta. Pin to a specific module version to avoid unexpected breaking changes:
 
-	go get github.com/OpenRouterTeam/go-sdk@v0.5.0
+	go get github.com/OpenRouterTeam/go-sdk@v0.5.2
 
 For full API documentation, visit: https://openrouter.ai/docs/client-sdks/go/overview
 

--- a/example_test.go
+++ b/example_test.go
@@ -18,7 +18,7 @@ func ExampleNew() {
 		openrouter.WithSecurity("your-api-key"),
 	)
 	fmt.Println(sdk.SDKVersion)
-	// Output: 0.5.0
+	// Output: 0.5.2
 }
 
 // Example demonstrates basic usage of the OpenRouter SDK for chat completions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ cd ../generation && go run .
 Each example pins a released SDK version in `go.mod`:
 
 ```go
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 ```
 
 This should match the version in [README.md](../README.md) and `.speakeasy/gen.lock` `releaseVersion`. CI runs `scripts/bump-examples.sh` after releases to keep these in sync.
@@ -51,7 +51,7 @@ This should match the version in [README.md](../README.md) and `.speakeasy/gen.l
 To use a different version:
 
 ```bash
-go get github.com/OpenRouterTeam/go-sdk@v0.5.0
+go get github.com/OpenRouterTeam/go-sdk@v0.5.2
 go run .
 ```
 

--- a/examples/chat-stream/go.mod
+++ b/examples/chat-stream/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/chat-stream
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/chat-stream/go.sum
+++ b/examples/chat-stream/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.0 h1:VIK2P2CSyIPJmMD1twe+GfkMQWAZw54xB/YizRoJPqU=
-github.com/OpenRouterTeam/go-sdk v0.5.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
+github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
+github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/chat/go.mod
+++ b/examples/chat/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/chat
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/chat/go.sum
+++ b/examples/chat/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.0 h1:VIK2P2CSyIPJmMD1twe+GfkMQWAZw54xB/YizRoJPqU=
-github.com/OpenRouterTeam/go-sdk v0.5.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
+github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
+github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/embed/go.mod
+++ b/examples/embed/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/embed
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/embed/go.sum
+++ b/examples/embed/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.0 h1:VIK2P2CSyIPJmMD1twe+GfkMQWAZw54xB/YizRoJPqU=
-github.com/OpenRouterTeam/go-sdk v0.5.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
+github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
+github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/generation/go.mod
+++ b/examples/generation/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/generation
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/generation/go.sum
+++ b/examples/generation/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.0 h1:VIK2P2CSyIPJmMD1twe+GfkMQWAZw54xB/YizRoJPqU=
-github.com/OpenRouterTeam/go-sdk v0.5.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
+github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
+github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/model/go.mod
+++ b/examples/model/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/model
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/model/go.sum
+++ b/examples/model/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.0 h1:VIK2P2CSyIPJmMD1twe+GfkMQWAZw54xB/YizRoJPqU=
-github.com/OpenRouterTeam/go-sdk v0.5.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
+github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
+github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/models/go.mod
+++ b/examples/models/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/models
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/models/go.sum
+++ b/examples/models/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.0 h1:VIK2P2CSyIPJmMD1twe+GfkMQWAZw54xB/YizRoJPqU=
-github.com/OpenRouterTeam/go-sdk v0.5.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
+github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
+github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/providers/go.mod
+++ b/examples/providers/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/providers
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/providers/go.sum
+++ b/examples/providers/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.0 h1:VIK2P2CSyIPJmMD1twe+GfkMQWAZw54xB/YizRoJPqU=
-github.com/OpenRouterTeam/go-sdk v0.5.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
+github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
+github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/rerank/go.mod
+++ b/examples/rerank/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/rerank
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.0
+require github.com/OpenRouterTeam/go-sdk v0.5.2
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/rerank/go.sum
+++ b/examples/rerank/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.0 h1:VIK2P2CSyIPJmMD1twe+GfkMQWAZw54xB/YizRoJPqU=
-github.com/OpenRouterTeam/go-sdk v0.5.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
+github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
+github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/scripts/bump-examples.sh
+++ b/scripts/bump-examples.sh
@@ -19,6 +19,10 @@ Usage: $(basename "$0") [vX.Y.Z]
 Bump pinned SDK versions in all examples/ modules and docs.
 
 If VERSION is omitted, reads releaseVersion from .speakeasy/gen.lock.
+
+Environment:
+  GO_GET_RETRIES   attempts to fetch the module from the proxy (default 20)
+  GO_GET_INTERVAL  seconds to wait between attempts (default 30)
 EOF
 }
 
@@ -91,6 +95,11 @@ go_get_with_retry() {
 		sleep "$GO_GET_INTERVAL"
 	done
 }
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
 
 VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then

--- a/scripts/bump-examples.sh
+++ b/scripts/bump-examples.sh
@@ -9,6 +9,7 @@ DOCS=(
 	examples/README.md
 	README.md
 	OVERVIEW.md
+	doc.go
 )
 
 usage() {
@@ -56,23 +57,38 @@ update_docs() {
 			s#(require github.com/OpenRouterTeam/go-sdk )v[0-9]+(?:\\.[0-9]+)*#\1${version}#g;
 		" "$doc"
 	done
+
+	# example_test.go asserts the SDK version via `// Output: X.Y.Z` (no `v`
+	# prefix, no module path), so it needs a dedicated substitution.
+	local bare="${version#v}"
+	if [[ -f example_test.go ]]; then
+		perl -pi -e "s#(// Output: )[0-9]+(?:\\.[0-9]+)*#\${1}${bare}#g" example_test.go
+	fi
 }
+
+# GOSUMDB=off: the checksum database (sum.golang.org) can lag the module proxy
+# by 10+ minutes after a tag publishes, but `go get` computes and records the
+# correct hash into go.sum directly from the proxy/tag without it. Waiting on
+# sum.golang.org is the reason release-time bumps used to fail; bypass it here
+# (downstream consumers still get sumdb-verified hashes once it backfills).
+GO_GET_RETRIES="${GO_GET_RETRIES:-20}"
+GO_GET_INTERVAL="${GO_GET_INTERVAL:-30}"
 
 go_get_with_retry() {
 	local dir="$1"
 	local version="$2"
 	local attempt
 
-	for attempt in 1 2 3 4 5 6; do
-		if (cd "$dir" && GOWORK=off go get "${MODULE}@${version}"); then
+	for attempt in $(seq 1 "$GO_GET_RETRIES"); do
+		if (cd "$dir" && GOWORK=off GOSUMDB=off go get "${MODULE}@${version}"); then
 			return 0
 		fi
-		if (( attempt == 6 )); then
-			echo "failed to fetch ${MODULE}@${version} for ${dir}" >&2
+		if (( attempt == GO_GET_RETRIES )); then
+			echo "failed to fetch ${MODULE}@${version} for ${dir} after ${GO_GET_RETRIES} attempts" >&2
 			return 1
 		fi
-		echo "waiting for ${MODULE}@${version} to appear on the module proxy (attempt ${attempt}/6)..." >&2
-		sleep 30
+		echo "waiting for ${MODULE}@${version} to appear on the module proxy (attempt ${attempt}/${GO_GET_RETRIES})..." >&2
+		sleep "$GO_GET_INTERVAL"
 	done
 }
 
@@ -100,7 +116,7 @@ for gomod in "${example_mods[@]}"; do
 	go_get_with_retry "$dir" "$VERSION"
 	(
 		cd "$dir"
-		GOWORK=off go mod tidy
+		GOWORK=off GOSUMDB=off go mod tidy
 	)
 done
 


### PR DESCRIPTION
## What

1. **Bump pinned SDK version `v0.5.0` → `v0.5.2`** across every hand-facing surface: install snippets (`README.md`, `OVERVIEW.md`, `doc.go`, `examples/README.md`), the eight `examples/*/go.mod` pins (+ `go.sum`), and the `ExampleNew` `// Output:` assertion.
2. **Fix the release-time auto-bump automation** so future releases stay in sync without manual PRs.

## Why the docs drifted

`scripts/bump-examples.sh` (run by `examples.yaml` on every release push) was **failing on every release** (0.5.1 and 0.5.2 both errored). Two root causes:

- **sum.golang.org lag.** The job runs `go get @vX.Y.Z` on the `gen.lock` push, but the Go checksum DB can lag the module proxy by 10+ minutes after a tag publishes. The retry window was only 6×30s (3 min), so it always gave up. Verified live: the proxy served v0.5.2 within seconds while `sum.golang.org/lookup/...@v0.5.2` still 404'd minutes later.
- **Incomplete coverage.** The script's `DOCS` list omitted `doc.go`, nothing bumped `example_test.go`, and the workflow's commit step only `git add`ed a subset of files.

## Automation fixes

- `GOSUMDB=off` on `go get` / `go mod tidy`: hashes are computed directly from the proxy/tag, so the bump no longer blocks on the checksum DB (consumers still get sumdb-verified hashes once it backfills).
- Retry window 6×30s → 20×30s (overridable via `GO_GET_RETRIES`/`GO_GET_INTERVAL`).
- Added `doc.go` to `DOCS` and a dedicated substitution for `example_test.go`'s `// Output:`.
- Commit step uses `git add -A` so all bumped files land.

## Verification

- `scripts/verify-examples.sh` (PINNED_BUILD=1): all examples pin v0.5.2, match gen.lock, build against workspace + pinned module ✅
- `go test ./...` passes, incl. the previously-failing `ExampleNew` ✅
- `bash -n scripts/bump-examples.sh` ✅

## Note

This is a docs/examples/CI change — it does **not** touch `.speakeasy/gen.lock` or `RELEASES.md`, so it will **not** trigger a Publish/release. (It will run a no-op Tagging job, which has no path filter.)