### PR TITLE
fix: bump examples v0.5.2 → v0.5.9 to match release version

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -117,7 +117,7 @@ go get github.com/OpenRouterTeam/go-sdk
 For beta releases, pin an explicit version:
 
 ```bash
-go get github.com/OpenRouterTeam/go-sdk@v0.5.2
+go get github.com/OpenRouterTeam/go-sdk@v0.5.9
 ```
 
 **Requirements:** Go 1.25 or higher

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To learn more, see the [API Reference](https://openrouter.ai/docs/sdks/go/api-re
 > This SDK is in **beta**. Pin to a specific version to avoid unexpected breaking changes:
 >
 > ```bash
-> go get github.com/OpenRouterTeam/go-sdk@v0.5.2
+> go get github.com/OpenRouterTeam/go-sdk@v0.5.9
 > ```
 
 <!-- No Summary [summary] -->

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ provider selection, and unified billing.
 
 This SDK is in beta. Pin to a specific module version to avoid unexpected breaking changes:
 
-	go get github.com/OpenRouterTeam/go-sdk@v0.5.2
+	go get github.com/OpenRouterTeam/go-sdk@v0.5.9
 
 For full API documentation, visit: https://openrouter.ai/docs/client-sdks/go/overview
 

--- a/example_test.go
+++ b/example_test.go
@@ -18,7 +18,7 @@ func ExampleNew() {
 		openrouter.WithSecurity("your-api-key"),
 	)
 	fmt.Println(sdk.SDKVersion)
-	// Output: 0.5.2
+	// Output: 0.5.9
 }
 
 // Example demonstrates basic usage of the OpenRouter SDK for chat completions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ cd ../generation && go run .
 Each example pins a released SDK version in `go.mod`:
 
 ```go
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 ```
 
 This should match the version in [README.md](../README.md) and `.speakeasy/gen.lock` `releaseVersion`. CI runs `scripts/bump-examples.sh` after releases to keep these in sync.
@@ -51,7 +51,7 @@ This should match the version in [README.md](../README.md) and `.speakeasy/gen.l
 To use a different version:
 
 ```bash
-go get github.com/OpenRouterTeam/go-sdk@v0.5.2
+go get github.com/OpenRouterTeam/go-sdk@v0.5.9
 go run .
 ```
 

--- a/examples/chat-stream/go.mod
+++ b/examples/chat-stream/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/chat-stream
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/chat-stream/go.sum
+++ b/examples/chat-stream/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
-github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
+github.com/OpenRouterTeam/go-sdk v0.5.9 h1:m122jNt7LXjdJiIK9TDQqvhsTcjLlJFPLlBg67nurZA=
+github.com/OpenRouterTeam/go-sdk v0.5.9/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/chat/go.mod
+++ b/examples/chat/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/chat
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/chat/go.sum
+++ b/examples/chat/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
-github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
+github.com/OpenRouterTeam/go-sdk v0.5.9 h1:m122jNt7LXjdJiIK9TDQqvhsTcjLlJFPLlBg67nurZA=
+github.com/OpenRouterTeam/go-sdk v0.5.9/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/embed/go.mod
+++ b/examples/embed/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/embed
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/embed/go.sum
+++ b/examples/embed/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
-github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
+github.com/OpenRouterTeam/go-sdk v0.5.9 h1:m122jNt7LXjdJiIK9TDQqvhsTcjLlJFPLlBg67nurZA=
+github.com/OpenRouterTeam/go-sdk v0.5.9/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/generation/go.mod
+++ b/examples/generation/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/generation
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/generation/go.sum
+++ b/examples/generation/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
-github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
+github.com/OpenRouterTeam/go-sdk v0.5.9 h1:m122jNt7LXjdJiIK9TDQqvhsTcjLlJFPLlBg67nurZA=
+github.com/OpenRouterTeam/go-sdk v0.5.9/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/model/go.mod
+++ b/examples/model/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/model
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/model/go.sum
+++ b/examples/model/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
-github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
+github.com/OpenRouterTeam/go-sdk v0.5.9 h1:m122jNt7LXjdJiIK9TDQqvhsTcjLlJFPLlBg67nurZA=
+github.com/OpenRouterTeam/go-sdk v0.5.9/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/models/go.mod
+++ b/examples/models/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/models
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/models/go.sum
+++ b/examples/models/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
-github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
+github.com/OpenRouterTeam/go-sdk v0.5.9 h1:m122jNt7LXjdJiIK9TDQqvhsTcjLlJFPLlBg67nurZA=
+github.com/OpenRouterTeam/go-sdk v0.5.9/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/providers/go.mod
+++ b/examples/providers/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/providers
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/providers/go.sum
+++ b/examples/providers/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
-github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
+github.com/OpenRouterTeam/go-sdk v0.5.9 h1:m122jNt7LXjdJiIK9TDQqvhsTcjLlJFPLlBg67nurZA=
+github.com/OpenRouterTeam/go-sdk v0.5.9/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/rerank/go.mod
+++ b/examples/rerank/go.mod
@@ -2,6 +2,6 @@ module github.com/OpenRouterTeam/go-sdk/examples/rerank
 
 go 1.25.10
 
-require github.com/OpenRouterTeam/go-sdk v0.5.2
+require github.com/OpenRouterTeam/go-sdk v0.5.9
 
 require github.com/spyzhov/ajson v0.8.0 // indirect

--- a/examples/rerank/go.sum
+++ b/examples/rerank/go.sum
@@ -1,5 +1,5 @@
-github.com/OpenRouterTeam/go-sdk v0.5.2 h1:ZdLtiXWpLhcaBWTFqeK+FSr7D6G+g2UXCH9wcEFEcZw=
-github.com/OpenRouterTeam/go-sdk v0.5.2/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
+github.com/OpenRouterTeam/go-sdk v0.5.9 h1:m122jNt7LXjdJiIK9TDQqvhsTcjLlJFPLlBg67nurZA=
+github.com/OpenRouterTeam/go-sdk v0.5.9/go.mod h1:GRqEs3Twjnq1GekyuZCxHi55X8rBiHYK860wc3IvyUE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

The `examples/` modules have been pinned to `go-sdk@v0.5.2` since #320, while releases advanced to **v0.5.9**. This makes the **Examples** CI check (`scripts/verify-examples.sh`) fail on `main`: its version-consistency gate requires `examples pin == .speakeasy/gen.lock releaseVersion` (currently `0.5.9`). The release-time auto-bump job (`examples.yaml` → `bump`) has never landed a commit, so the drift accumulated across 7 releases.

This PR bumps all 8 example modules and the tracked docs to `v0.5.9` — exactly what `scripts/bump-examples.sh v0.5.9` produces:

- `examples/*/go.mod` + `examples/*/go.sum` (8 modules) → v0.5.9 (go.sum hashes from sum.golang.org)
- `README.md`, `OVERVIEW.md`, `doc.go`, `examples/README.md` → `go get ...@v0.5.9`
- `example_test.go` → `// Output: 0.5.9`

## Why not via the script

`scripts/bump-examples.sh` runs `go get` + `go mod tidy`, which needs a Go toolchain (not available where this was prepared). The edits are byte-identical to what the script emits; the checksums come straight from the official sum database.

## Verification

- Version-consistency gate simulated locally: examples pin `v0.5.9` == releaseVersion `0.5.9` ✓
- Example build + `go vet` run in the Examples CI workflow (`setup-go` + `PINNED_BUILD`).

## Test plan

- [ ] Examples CI check passes (version gate + build + vet)
- [ ] Confirm this is the right base version (v0.5.9 = latest published tag)