### PR TITLE
ci: allow examples to lag gen.lock on pending-release PRs

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -118,3 +118,6 @@ jobs:
         run: scripts/verify-examples.sh
         env:
           PINNED_BUILD: auto
+          # On Speakeasy release PRs the examples necessarily lag gen.lock's
+          # new releaseVersion until the post-merge bump job runs — allow it.
+          ALLOW_PENDING_RELEASE: ${{ startsWith(github.head_ref, 'speakeasy-sdk-regen-') && '1' || '0' }}

--- a/scripts/verify-examples.sh
+++ b/scripts/verify-examples.sh
@@ -6,6 +6,7 @@ cd "$ROOT"
 
 MODULE="github.com/OpenRouterTeam/go-sdk"
 PINNED_BUILD="${PINNED_BUILD:-auto}"
+ALLOW_PENDING_RELEASE="${ALLOW_PENDING_RELEASE:-0}"
 
 usage() {
 	cat <<EOF
@@ -18,6 +19,12 @@ Environment:
     auto  build against the pinned module when examples match gen.lock (default)
     1     always build with GOWORK=off
     0     skip pinned-module builds
+  ALLOW_PENDING_RELEASE=1
+    allow examples to pin an older version than gen.lock's releaseVersion.
+    For release (speakeasy-sdk-regen-*) PRs: the new version has no published
+    tag yet, so example go.mod pins cannot be bumped until after the merge
+    (the "Bump examples on release" job does it). Examples must still agree
+    with each other and still compile against the workspace SDK.
 EOF
 }
 
@@ -41,6 +48,11 @@ discover_examples() {
 
 example_version() {
 	awk -v module="$MODULE" '$1 == "require" && $2 == module { print $3; exit }' "$1/go.mod"
+}
+
+# is_older_version A B — true when semver A < B (so A lags a pending release B).
+is_older_version() {
+	[[ "$1" != "$2" && "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" == "$1" ]]
 }
 
 collect_examples() {
@@ -71,6 +83,11 @@ check_versions() {
 
 	lock_version="$(read_lock_version)"
 	if [[ -n "$lock_version" && "$expected" != "$lock_version" ]]; then
+		if [[ "$ALLOW_PENDING_RELEASE" == "1" ]] && is_older_version "$expected" "$lock_version"; then
+			echo "examples pin ${expected}, gen.lock releaseVersion is ${lock_version} (pending release — allowed)"
+			echo "the post-merge 'Bump examples on release' job will bump the pins"
+			return 0
+		fi
 		echo "examples pin ${expected} but .speakeasy/gen.lock releaseVersion is ${lock_version}" >&2
 		echo "run: scripts/bump-examples.sh ${lock_version}" >&2
 		exit 1


### PR DESCRIPTION
## TL;DR

Fixes the wedged SDK generation pipeline (nightly `Generate SDK` failing since Jul 8 with `external changes detected on branch speakeasy-sdk-regen-1783434655`).

## Root cause

#329 added a pre-merge doc-sync commit on Speakeasy regen branches so pkg.go.dev renders the right version from the release tag's tree. That push triggers the `Examples` workflow on the regen PR, where **`Verify examples` always fails by design**: `examples/*/go.mod` still pin the previous released version because the new tag doesn't exist yet — the post-merge "Bump examples on release" job is what bumps them. (Before #329 this check effectively never ran on regen PRs, since speakeasybot pushes left workflows in `action_required`.)

The failing check blocks auto-merge, stranding the regen branch with a non-Speakeasy commit — and every subsequent generation run aborts because Speakeasy refuses to reuse a branch with external commits. See PR #349 / run [29060329729](https://github.com/OpenRouterTeam/go-sdk/actions/runs/29060329729).

## Fix

- `scripts/verify-examples.sh`: new `ALLOW_PENDING_RELEASE=1` env — examples pinning an **older** version than `gen.lock`'s `releaseVersion` pass the version check with a notice. Examples must still agree with each other, still compile against the workspace SDK, and examples **ahead** of `gen.lock` still fail.
- `.github/workflows/examples.yaml`: enable it only for `speakeasy-sdk-regen-*` head refs.

The pinned-module build was already skipped in this state (`PINNED_BUILD=auto` only builds pinned when versions match), so no behavior change there.

## Testing

Ran the version check in all four states locally:

| examples vs gen.lock | ALLOW_PENDING_RELEASE | result |
|---|---|---|
| behind (v0.5.12 vs v0.5.13) | 0 | fail (unchanged) |
| behind (v0.5.12 vs v0.5.13) | 1 | **pass with notice** |
| in sync | 1 | pass |
| ahead (v0.5.12 vs v0.5.11) | 1 | fail |

## Unwedge (separate, after this merges)

Close #349 and delete the stranded `speakeasy-sdk-regen-1783434655` branch, then re-run Generate SDK so a fresh regen PR flows through cleanly.