### PR TITLE
ci: retry direct merge while GitHub recomputes mergeability

### DIFF
--- a/.github/workflows/auto-merge-speakeasy-pr.yaml
+++ b/.github/workflows/auto-merge-speakeasy-pr.yaml
@@ -237,9 +237,32 @@ jobs:
           fi
 
           MERGE_METHOD=""
+          # Retry direct merges: right after the doc-sync push GitHub is still
+          # recomputing mergeability, and merge attempts fail transiently with
+          # "Pull Request is not mergeable" even though the PR ends up CLEAN.
+          merge_with_retry() {
+            local pr=$1
+            local attempts=8
+            local interval=15
+
+            for attempt in $(seq 1 "$attempts"); do
+              if gh pr merge "$pr" --repo "$REPO" --squash --delete-branch 2> /tmp/gh-direct-merge.err; then
+                return 0
+              fi
+              if ! grep -qi 'not mergeable' /tmp/gh-direct-merge.err; then
+                cat /tmp/gh-direct-merge.err >&2
+                return 1
+              fi
+              echo "PR #$pr not mergeable yet (mergeability recompute) — retrying in ${interval}s (attempt $attempt/$attempts)..."
+              sleep "$interval"
+            done
+            cat /tmp/gh-direct-merge.err >&2
+            return 1
+          }
+
           # Prefer GitHub auto-merge when required checks exist; otherwise
           # squash-merge directly after checks pass (sdk-release-prs.yaml pattern).
-          AUTO_MERGE_NOOP_PATTERN='is in clean status|protected branch rules|Branch does not have required protected branch rules'
+          AUTO_MERGE_NOOP_PATTERN='is in clean status|protected branch rules|Branch does not have required protected branch rules|not mergeable'
           if gh pr merge "$PR_NUM" --repo "$REPO" --squash --auto --delete-branch 2> /tmp/gh-merge.err; then
             MERGE_METHOD="auto-merge queued"
             echo "Auto-merge enabled for Speakeasy PR #$PR_NUM"
@@ -247,7 +270,7 @@ jobs:
             echo "Auto-merge not applicable — waiting for checks, then merging PR #$PR_NUM directly"
             cat /tmp/gh-merge.err >&2
             wait_for_checks "$PR_NUM"
-            gh pr merge "$PR_NUM" --repo "$REPO" --squash --delete-branch
+            merge_with_retry "$PR_NUM"
             MERGE_METHOD="direct squash (checks passed)"
           else
             echo "::error::Failed to enable auto-merge on Speakeasy PR #$PR_NUM"


### PR DESCRIPTION
## TL;DR

Follow-up to #367. With the `Verify examples` blocker fixed, the first clean regen run ([29115606490](https://github.com/OpenRouterTeam/go-sdk/actions/runs/29115606490), PR #368) exposed a race in the auto-merge step: the doc-sync push invalidates GitHub's cached mergeability, so the immediate merge attempt fails with `GraphQL: Pull Request is not mergeable (mergePullRequest)` — even though the PR settles to `MERGEABLE`/`CLEAN` seconds later (I merged #368 manually right after with no changes).

## Fix

- Add `not mergeable` to the auto-merge noop pattern so the transient error takes the wait-then-direct-merge path instead of hard-failing.
- Wrap the direct squash in `merge_with_retry`: retry `not mergeable` errors every 15s for up to 8 attempts (~2 min); any other error still fails immediately.

## Testing

The failure is only reproducible inside a live Generate run (needs the doc-sync push + immediate merge). The next regen PR (nightly, or the next spec change) exercises this path; logic is a straight retry loop around the existing `gh pr merge` call.